### PR TITLE
➕ Add uploader templates

### DIFF
--- a/uploaders/UPLOADERS.md
+++ b/uploaders/UPLOADERS.md
@@ -1,0 +1,12 @@
+# TypeX Uploaders
+These uploaders are made with ShareX in mind, but can be adapted to other uploaders.
+Please make a Pull Request with other uploader configurations with the scheme of
+`uploader_type.json`.
+
+## Images
+Images are sent to the `/api/upload/` endpoint with Multipart Form-Data. The payload key is `file`.
+
+---
+
+## URLs
+URLs are sent to the `/api/shorten/` endpoint with raw data. The payload key is `url`.

--- a/uploaders/sharex_images.json
+++ b/uploaders/sharex_images.json
@@ -1,0 +1,15 @@
+{
+	"Version": "13.1.0",
+	"Name": "<YOUR UPLOADER NAME>",
+	"DestinationType": "ImageUploader",
+	"RequestMethod": "POST",
+	"RequestURL": "https://<YOUR DOMAIN>/api/upload",
+	"Headers": {
+		"authorization": "<YOUR TOKEN>"
+	},
+	"Body": "MultipartFormData",
+	"Arguments": {
+		"file": "@1"
+	},
+	"FileFormName": "file"
+}

--- a/uploaders/sharex_urls.json
+++ b/uploaders/sharex_urls.json
@@ -1,0 +1,12 @@
+{
+	"Version": "13.1.0",
+	"Name": "<YOUR UPLOADER NAME>",
+	"DestinationType": "URLShortener",
+	"RequestMethod": "POST",
+	"RequestURL": "https://<YOUR DOMAIN>/api/shorten",
+	"Headers": {
+		"authorization": "<YOUR TOKEN>"
+	},
+	"Body": "JSON",
+	"Data": "{\n  \"url\": \"$input$\"\n}"
+}


### PR DESCRIPTION
Added an `uploaders` folder that will contain all TypeX uploader templates, with included ShareX image and URL uploaders.
An additional UPLOADERS.md file was added to further explain how the uploaders are used.