### PR TITLE
Allow uploader route to be root

### DIFF
--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -79,9 +79,9 @@ async function handler(req: NextApiReq, res: NextApiRes) {
     Logger.get('image').info(`User ${user.username} (${user.id}) uploaded an image ${image.file} (${image.id})`);
     if (user.domains.length) {
       const domain = user.domains[Math.floor(Math.random() * user.domains.length)];
-      files.push(`${domain}${zconfig.uploader.route}/${invis ? invis.invis : image.file}`);
+      files.push(`${domain}${zconfig.uploader.route === '/' ? '' : zconfig.uploader.route}/${invis ? invis.invis : image.file}`);
     } else {
-      files.push(`${zconfig.core.secure ? 'https' : 'http'}://${req.headers.host}${zconfig.uploader.route}/${invis ? invis.invis : image.file}`);
+      files.push(`${zconfig.core.secure ? 'https' : 'http'}://${req.headers.host}${zconfig.uploader.route === '/' ? '' : zconfig.uploader.route}/${invis ? invis.invis : image.file}`);
     }
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -63,7 +63,7 @@ export default class Server {
       },
     });
 
-    this.router.on('GET', `${config.uploader.route}/:id`, async (req, res, params) => {
+    this.router.on('GET', config.uploader.route === '/' ? '/:id(^[^\\.]+\\.[^\\.]+)' : `${config.uploader.route}/:id`, async (req, res, params) => {
       const image = await this.prisma.image.findFirst({
         where: {
           OR: [


### PR DESCRIPTION
This will allow the uploader.route config to be set to `/`. When this is set, files with an extension will be matched by regex and made available directly on the root path.