### PR TITLE
S3 endpoint support

### DIFF
--- a/src/lib/datasource/S3.ts
+++ b/src/lib/datasource/S3.ts
@@ -9,11 +9,13 @@ export class S3 extends Datasource {
   public constructor(
     public accessKey: string,
     public secretKey: string,
+    public endpoint: string,
     public bucket: string,
   ) {
     super();
     this.s3 = new AWS.S3({
       accessKeyId: accessKey,
+      endpoint: endpoint,
       secretAccessKey: secretKey,
     });
   }

--- a/src/lib/ds.ts
+++ b/src/lib/ds.ts
@@ -6,7 +6,7 @@ if (!global.datasource) {
   switch (config.datasource.type) {
   case 's3':
     Logger.get('datasource').info(`Using S3(${config.datasource.s3.bucket}) datasource`);
-    global.datasource = new S3(config.datasource.s3.access_key_id, config.datasource.s3.secret_access_key,config.datasource.s3.endpoint, config.datasource.s3.bucket);
+    global.datasource = new S3(config.datasource.s3.access_key_id, config.datasource.s3.secret_access_key, config.datasource.s3.endpoint, config.datasource.s3.bucket);
     break;
   case 'local':
     Logger.get('datasource').info(`Using local(${config.datasource.local.directory}) datasource`);

--- a/src/lib/ds.ts
+++ b/src/lib/ds.ts
@@ -6,7 +6,7 @@ if (!global.datasource) {
   switch (config.datasource.type) {
   case 's3':
     Logger.get('datasource').info(`Using S3(${config.datasource.s3.bucket}) datasource`);
-    global.datasource = new S3(config.datasource.s3.access_key_id, config.datasource.s3.secret_access_key, config.datasource.s3.bucket);
+    global.datasource = new S3(config.datasource.s3.access_key_id, config.datasource.s3.secret_access_key,config.datasource.s3.endpoint, config.datasource.s3.bucket);
     break;
   case 'local':
     Logger.get('datasource').info(`Using local(${config.datasource.local.directory}) datasource`);

--- a/src/lib/readConfig.ts
+++ b/src/lib/readConfig.ts
@@ -68,6 +68,7 @@ function tryReadEnv(): Config {
       s3: {
         access_key_id: undefined,
         secret_access_key: undefined,
+        endpoint: undefined,
         bucket: undefined,
       },
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface ConfigLocalDatasource {
 export interface ConfigS3Datasource {
   access_key_id: string;
   secret_access_key: string;
+  endpoint: string;
   bucket: string;
 }
 

--- a/src/server/validateConfig.ts
+++ b/src/server/validateConfig.ts
@@ -19,6 +19,7 @@ const validator = object({
     s3: object({
       access_key_id: string(),
       secret_access_key: string(),
+      endpoint: string(),
       bucket: string(),
     }).notRequired(),
   }).required(),
@@ -48,6 +49,7 @@ export default function validate(config): Config {
       const errors = [];
       if (!validated.datasource.s3.access_key_id) errors.push('datasource.s3.access_key_id is a required field');
       if (!validated.datasource.s3.secret_access_key) errors.push('datasource.s3.secret_access_key is a required field');
+      if (!validated.datasource.s3.endpoint) errors.push('datasource.s3.endpoint is a required field');
       if (!validated.datasource.s3.bucket) errors.push('datasource.s3.bucket is a required field');
       if (errors.length) throw { errors }; 
     }


### PR DESCRIPTION
Adding endpoint support to S3 allows for other S3-compatible uploaders to be used