### PR TITLE
Replace core.secure with core.https

### DIFF
--- a/src/lib/config/readConfig.ts
+++ b/src/lib/config/readConfig.ts
@@ -42,7 +42,7 @@ export default function readConfig() {
   }
 
   const maps = [
-    map('CORE_HTTPS', 'boolean', 'core.secure'),
+    map('CORE_HTTPS', 'boolean', 'core.https'),
     map('CORE_SECRET', 'string', 'core.secret'),
     map('CORE_HOST', 'string', 'core.host'),
     map('CORE_PORT', 'number', 'core.port'),


### PR DESCRIPTION
Currently any code (such as ``api/shorten.ts`` and ``api/upload.ts``) that uses the ``core.https`` env var doesn't work and always returns a not-secure link, despite users setting the CORE_HTTPS variable to `true` in their local config.

That's because CORE_HTTPS has been mapped as ``core.secure`` in the config parser instead of ``core.https`` which is what the active codebase uses. This PR renames core.secure back to core.https to restore functionality.