### PR TITLE
fix: NaN on stat card

### DIFF
--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -62,7 +62,7 @@ export default function StatCard({ stat }: StatsGridProps) {
                 weight={500}
                 className={classes.diff}
               >
-                <span>{stat.diff}%</span>
+                <span>{stat.diff === Infinity ? '∞' : stat.diff}%</span>
                 {
                   stat.diff >= 0 ? (
                     <ArrowUpRight size={16} />

--- a/src/lib/utils/client.ts
+++ b/src/lib/utils/client.ts
@@ -85,5 +85,8 @@ export function parseExpiry(header: string): Date | null {
 }
 
 export function percentChange(initial: number, final: number) {
+  if(initial === 0 && final === 0) return 0;
+  if(initial === 0) return Infinity;
+
   return ((final - initial) / initial) * 100;
 }

--- a/src/lib/utils/client.ts
+++ b/src/lib/utils/client.ts
@@ -85,8 +85,8 @@ export function parseExpiry(header: string): Date | null {
 }
 
 export function percentChange(initial: number, final: number) {
-  if(initial === 0 && final === 0) return 0;
-  if(initial === 0) return Infinity;
+  if (initial === 0 && final === 0) return 0;
+  if (initial === 0) return Infinity;
 
   return ((final - initial) / initial) * 100;
 }


### PR DESCRIPTION
Small PR that prevents NaN from showing (due to dividing by 0) on stat card.
![image](https://user-images.githubusercontent.com/14848722/193717637-ae182ce8-50a8-4242-9b2a-58136d50fec2.png)
