### PR TITLE
Improve query-size

### DIFF
--- a/src/lib/datasources/Local.ts
+++ b/src/lib/datasources/Local.ts
@@ -25,6 +25,7 @@ export class Local extends Datasource {
       await rm(join(process.cwd(), this.path, files[i]));
     }
   }
+
   public get(file: string): ReadStream {
     const full = join(process.cwd(), this.path, file);
     if (!existsSync(full)) return null;
@@ -37,7 +38,9 @@ export class Local extends Datasource {
   }
 
   public async size(file: string): Promise<number> {
-    const stats = await stat(join(process.cwd(), this.path, file));
+    const full = join(process.cwd(), this.path, file);
+    if (!existsSync(full)) return 0;
+    const stats = await stat(full);
 
     return stats.size;
   }

--- a/src/scripts/query-size.ts
+++ b/src/scripts/query-size.ts
@@ -8,13 +8,41 @@ async function main() {
   await migrations();
 
   const prisma = new PrismaClient();
+  let notFound = false;
 
-  const files = await prisma.file.findMany();
+  const files = await prisma.file.findMany({
+    ...(process.argv.includes('--force-update')
+      ? undefined
+      : {
+          where: {
+            size: 0,
+          },
+        }),
+    select: {
+      id: true,
+      name: true,
+    },
+  });
 
   console.log(`The script will attempt to query the size of ${files.length} files.`);
 
   for (let i = 0; i !== files.length; ++i) {
     const file = files[i];
+    if (!datasource.get(file.name)) {
+      if (process.argv.includes('--force-delete')) {
+        console.log(`File ${file.name} does not exist. Deleting...`);
+        await prisma.file.delete({
+          where: {
+            id: file.id,
+          },
+        });
+        continue;
+      } else {
+        notFound ? null : (notFound = true);
+        continue;
+      }
+    }
+
     const size = await datasource.size(file.name);
     if (size === 0) {
       console.log(`File ${file.name} has a size of 0 bytes. Ignoring...`);
@@ -31,7 +59,11 @@ async function main() {
     }
   }
 
-  console.log('Done.');
+  notFound
+    ? console.log(
+        'At least one file has been found to not exist in the datasource but was on the database. To remove these files, run the script with the --force-delete flag.'
+      )
+    : console.log('Done.');
   process.exit(0);
 }
 

--- a/src/scripts/query-size.ts
+++ b/src/scripts/query-size.ts
@@ -21,6 +21,7 @@ async function main() {
     select: {
       id: true,
       name: true,
+      size: true,
     },
   });
 


### PR DESCRIPTION
This adds a new function to the script to delete files that don't exist in the datasource, but do exist in the db. It'll skip by default but if passed `--force-delete`, it'll delete the entries in the db. Along with that, the default function of the script will update files where the size is 0. If all files needed to be updated with a new size, you can pass `--force-update` and it'll update the sizes to *ALL* files in the db.

Oh and had Local's datasource.size() return 0 if the file didn't exist.