### PR TITLE
some fixes

### DIFF
--- a/src/components/pages/Invites.tsx
+++ b/src/components/pages/Invites.tsx
@@ -30,7 +30,7 @@ import {
 import MutedText from 'components/MutedText';
 import useFetch from 'hooks/useFetch';
 import { listViewInvitesSelector } from 'lib/recoil/settings';
-import { expireText, relativeTime } from 'lib/utils/client';
+import { expireReadToDate, expireText, relativeTime } from 'lib/utils/client';
 import { DataTable, DataTableSortStatus } from 'mantine-datatable';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -50,21 +50,7 @@ function CreateInviteModal({ open, setOpen, updateInvites }) {
     if (!expires.includes(values.expires)) return form.setFieldError('expires', 'Invalid expiration');
     if (values.count < 1 || values.count > 100)
       return form.setFieldError('count', 'Must be between 1 and 100');
-    const expiresAt =
-      values.expires === 'never'
-        ? null
-        : new Date(
-            {
-              '30m': Date.now() + 30 * 60 * 1000,
-              '1h': Date.now() + 60 * 60 * 1000,
-              '6h': Date.now() + 6 * 60 * 60 * 1000,
-              '12h': Date.now() + 12 * 60 * 60 * 1000,
-              '1d': Date.now() + 24 * 60 * 60 * 1000,
-              '3d': Date.now() + 3 * 24 * 60 * 60 * 1000,
-              '5d': Date.now() + 5 * 24 * 60 * 60 * 1000,
-              '7d': Date.now() + 7 * 24 * 60 * 60 * 1000,
-            }[values.expires]
-          );
+    const expiresAt = values.expires === 'never' ? null : expireReadToDate(values.expires);
 
     setOpen(false);
 

--- a/src/components/pages/Invites.tsx
+++ b/src/components/pages/Invites.tsx
@@ -85,6 +85,7 @@ function CreateInviteModal({ open, setOpen, updateInvites }) {
           label='Expires'
           id='expires'
           {...form.getInputProps('expires')}
+          maxDropdownHeight={100}
           data={[
             { value: '30min', label: '30 minutes' },
             { value: '1h', label: '1 hour' },

--- a/src/components/pages/Invites.tsx
+++ b/src/components/pages/Invites.tsx
@@ -36,12 +36,12 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-const expires = ['30m', '1h', '6h', '12h', '1d', '3d', '5d', '7d', 'never'];
+const expires = ['30min', '1h', '6h', '12h', '1d', '3d', '5d', '7d', 'never'];
 
 function CreateInviteModal({ open, setOpen, updateInvites }) {
   const form = useForm({
     initialValues: {
-      expires: '30m',
+      expires: '30min',
       count: 1,
     },
   });
@@ -55,7 +55,7 @@ function CreateInviteModal({ open, setOpen, updateInvites }) {
     setOpen(false);
 
     const res = await useFetch('/api/auth/invite', 'POST', {
-      expiresAt,
+      expiresAt: expiresAt === null ? null : `date=${expiresAt.toISOString()}`,
       count: values.count,
     });
 
@@ -86,7 +86,7 @@ function CreateInviteModal({ open, setOpen, updateInvites }) {
           id='expires'
           {...form.getInputProps('expires')}
           data={[
-            { value: '30m', label: '30 minutes' },
+            { value: '30min', label: '30 minutes' },
             { value: '1h', label: '1 hour' },
             { value: '6h', label: '6 hours' },
             { value: '12h', label: '12 hours' },

--- a/src/pages/api/auth/invite.ts
+++ b/src/pages/api/auth/invite.ts
@@ -3,6 +3,7 @@ import Logger from 'lib/logger';
 import { NextApiReq, NextApiRes, UserExtended, withZipline } from 'lib/middleware/withZipline';
 import prisma from 'lib/prisma';
 import { randomChars } from 'lib/util';
+import { parseExpiry } from 'lib/utils/client';
 
 const logger = Logger.get('invite');
 
@@ -15,11 +16,8 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
       count: number;
     };
 
-    const expiry = expiresAt ? new Date(expiresAt) : null;
-    if (expiry) {
-      if (!expiry.getTime()) return res.badRequest('invalid date');
-      if (expiry.getTime() < Date.now()) return res.badRequest('date is in the past');
-    }
+    const expiry = parseExpiry(expiresAt);
+    if (!expiry) return res.badRequest('invalid date');
     const counts = count ? count : 1;
 
     if (counts > 1) {

--- a/src/pages/api/user/files.ts
+++ b/src/pages/api/user/files.ts
@@ -83,6 +83,7 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
       maxViews: number;
       views: number;
       size: number;
+      originalName: string;
     }[] = await prisma.file.findMany({
       where: {
         userId: user.id,
@@ -102,6 +103,7 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
         folderId: true,
         maxViews: true,
         size: true,
+        originalName: true,
       },
     });
 

--- a/src/pages/api/user/folders/index.ts
+++ b/src/pages/api/user/folders/index.ts
@@ -58,12 +58,13 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
 
     return res.json(folder);
   } else {
+    if (req.query.files instanceof Array) req.query.files = req.query.files[0];
     const folders = await prisma.folder.findMany({
       where: {
         userId: user.id,
       },
       select: {
-        files: !!req.query.files,
+        files: ((req.query.files as string) ?? 'false').toLowerCase() === 'true',
         id: true,
         name: true,
         userId: true,
@@ -76,7 +77,7 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
       },
     });
 
-    if (req.query.files) {
+    if (((req.query.files as string) ?? 'false').toLowerCase() === 'true') {
       for (let i = 0; i !== folders.length; ++i) {
         const folder = folders[i];
         for (let j = 0; j !== folders[i].files.length; ++j) {


### PR DESCRIPTION
some fixes for diced/zipline-docs#50

/api/auth/invite can now use relative time, at the cost of needing `date=` prefixed for timestamps