### PR TITLE
Add file table as alternative view

### DIFF
--- a/src/components/pages/Files/FileTable.tsx
+++ b/src/components/pages/Files/FileTable.tsx
@@ -1,0 +1,224 @@
+import { ActionIcon, Group, Tooltip } from '@mantine/core';
+import { useClipboard } from '@mantine/hooks';
+import { showNotification } from '@mantine/notifications';
+import {
+  IconClipboardCopy,
+  IconExternalLink,
+  IconFolderShare,
+  IconFolderX,
+  IconPhotoCancel,
+  IconPhotoStar,
+  IconPhotoMinus,
+} from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+import { ApiError } from 'hooks/useFetch';
+import { DataTable, DataTableSortStatus } from 'mantine-datatable';
+import { useFileDelete, useFileFavorite } from 'lib/queries/files';
+
+export default function FileTable({ files }) {
+
+  const [sortStatus, setSortStatus] = useState<DataTableSortStatus>({
+    columnAccessor: 'createdAt',
+    direction: 'desc',
+  });
+  const [records, setRecords] = useState(files.data);
+
+  const [open, setOpen] = useState(false);
+
+  const deleteFile = useFileDelete();
+  const favoriteFile = useFileFavorite();
+
+  const clipboard = useClipboard();
+
+  useEffect(() => {
+    setRecords(files.data);
+  }, [files.data]);
+
+  useEffect(() => {
+    if (!records || records.length === 0) return;
+
+    const sortedRecords = [...records].sort((a, b) => {
+      if (sortStatus.direction === 'asc') {
+        return a[sortStatus.columnAccessor] > b[sortStatus.columnAccessor] ? 1 : -1;
+      }
+
+      return a[sortStatus.columnAccessor] < b[sortStatus.columnAccessor] ? 1 : -1;
+    });
+
+    setRecords(sortedRecords);
+  }, [sortStatus]);
+
+  const handleCopy = (file) => {
+    clipboard.copy(`${window.location.protocol}//${window.location.host}${file.url}`);
+    setOpen(false);
+    if (!navigator.clipboard)
+      showNotification({
+        title: 'Unable to copy to clipboard',
+        message: 'Zipline is unable to copy to clipboard due to security reasons.',
+        color: 'red',
+      });
+    else
+      showNotification({
+        title: 'Copied to clipboard',
+        message: '',
+        icon: <IconClipboardCopy size='1rem' />,
+      });
+  };
+
+  const handleDelete = async (file) => {
+    deleteFile.mutate(file.id, {
+      onSuccess: () => {
+        showNotification({
+          title: 'File Deleted',
+          message: '',
+          color: 'green',
+          icon: <IconPhotoMinus size='1rem' />,
+        });
+      },
+
+      onError: (res: ApiError) => {
+        showNotification({
+          title: 'Failed to delete file',
+          message: res.error,
+          color: 'red',
+          icon: <IconPhotoCancel size='1rem' />,
+        });
+      },
+
+      onSettled: () => {
+        setOpen(false);
+      },
+    });
+  };
+
+  const handleFavorite = async (file) => {
+    favoriteFile.mutate(
+      { id: file.id, favorite: !file.favorite },
+      {
+        onSuccess: () => {
+          showNotification({
+            title: 'The file is now ' + (!file.favorite ? 'favorited' : 'unfavorited'),
+            message: '',
+            icon: <IconPhotoStar size='1rem' />,
+          });
+        },
+
+        onError: (res: { error: string }) => {
+          showNotification({
+            title: 'Failed to favorite file',
+            message: res.error,
+            color: 'red',
+            icon: <IconPhotoCancel size='1rem' />,
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <DataTable
+      withBorder
+      borderRadius='md'
+      highlightOnHover
+      verticalSpacing='sm'
+      columns={[
+        { accessor: 'id', title: 'ID', sortable: true },
+        { accessor: 'name', sortable: true },
+        { accessor: 'type', sortable: true },
+        { accessor: 'views', sortable: true },
+        {
+          accessor: 'createdAt',
+          title: 'Created',
+          sortable: true,
+          render: (file) => new Date(file.createdAt).toLocaleString(),
+        },
+        {
+          accessor: 'expiresAt',
+          title: 'Expires',
+          sortable: true,
+          render: (file) => new Date(file.expiresAt).toLocaleString(),
+        },
+        {
+          accessor: 'actions',
+          textAlignment: 'right',
+          render: (file) => (
+            <Group spacing={4} position='right' noWrap>
+              <Tooltip label={file.favorite ? 'Unfavorite' : 'Favorite'}>
+                <ActionIcon
+                  color={file.favorite ? 'yellow' : 'gray'}
+                  variant='filled'
+                  onClick={handleFavorite}
+                >
+                  <IconPhotoStar size='1rem' />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label='Open file in new tab'>
+                <ActionIcon
+                  onClick={() => window.open(file.url, '_blank')}
+                  variant='subtle'
+                  color='primary'
+                >
+                  <IconFolderShare size='1rem' />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label='Copy URL'>
+                <ActionIcon color='blue' variant='filled' onClick={handleCopy}>
+                  <IconClipboardCopy size='1rem' />
+                </ActionIcon>
+              </Tooltip>
+              <Tooltip label='Delete file'>
+                <ActionIcon onClick={() => handleDelete(file)} variant='subtle' color='red'>
+                  <IconFolderX size='1rem' />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          ),
+        },
+      ]}
+      sortStatus={sortStatus}
+      onSortStatusChange={setSortStatus}
+      records={records ?? []}
+      fetching={files.isLoading}
+      loaderBackgroundBlur={5}
+      minHeight='calc(100vh - 200px)'
+      loaderVariant='dots'
+      rowContextMenu={{
+        shadow: 'xl',
+        borderRadius: 'md',
+        items: (file) => [
+          {
+            key: 'favorite',
+            title: file.favorite ? 'Unfavorite' : 'Favorite',
+            icon: <IconPhotoStar size='1rem' />,
+            onClick: () => handleFavorite(file),
+          },
+          {
+            key: 'openFile',
+            title: 'Open file in a new tab',
+            icon: <IconExternalLink size='1rem' />,
+            onClick: () => window.open(file.url, '_blank'),
+          },
+          {
+            key: 'copyLink',
+            title: 'Copy file link to clipboard',
+            icon: <IconClipboardCopy size='1rem' />,
+            onClick: () => {
+              clipboard.copy(file.url);
+            },
+          },
+          {
+            key: 'deleteFile',
+            title: 'Delete file',
+            icon: <IconFolderX size='1rem' />,
+            onClick: () => handleDelete(file),
+          },
+        ],
+      }}
+      onCellClick={({ column, record: file }) => {
+        if (column.accessor === 'actions') return;
+
+        setOpen(true);
+      }}
+    />
+  )
+}

--- a/src/components/pages/Files/index.tsx
+++ b/src/components/pages/Files/index.tsx
@@ -1,17 +1,27 @@
 import { Accordion, ActionIcon, Box, Group, Pagination, SimpleGrid, Title, Tooltip } from '@mantine/core';
-import { IconFileUpload, IconPhotoUp } from '@tabler/icons-react';
+import {
+  IconFileUpload,
+  IconGridDots,
+  IconList,
+  IconPhotoUp,
+} from '@tabler/icons-react';
 import File from 'components/File';
 import useFetch from 'hooks/useFetch';
 import { usePaginatedFiles } from 'lib/queries/files';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { listViewFilesSelector } from 'lib/recoil/settings';
+import { useRecoilState } from 'recoil';
 import FilePagation from './FilePagation';
 import PendingFilesModal from './PendingFilesModal';
+import FileTable from './FileTable';
 
 export default function Files({ disableMediaPreview, exifEnabled, queryPage, compress }) {
   const [favoritePage, setFavoritePage] = useState(1);
   const [favoriteNumPages, setFavoriteNumPages] = useState(0);
   const favoritePages = usePaginatedFiles(favoritePage, 'media', true);
+
+  const [listView, setListView] = useRecoilState(listViewFilesSelector);
 
   const [open, setOpen] = useState(false);
 
@@ -31,6 +41,11 @@ export default function Files({ disableMediaPreview, exifEnabled, queryPage, com
         <ActionIcon component={Link} href='/dashboard/upload/file' variant='filled' color='primary'>
           <IconFileUpload size='1rem' />
         </ActionIcon>
+        <Tooltip label={listView ? 'Switch to grid view' : 'Switch to list view'}>
+          <ActionIcon variant='filled' color='primary' onClick={() => setListView(!listView)}>
+            {listView ? <IconList size='1rem' /> : <IconGridDots size='1rem' />}
+          </ActionIcon>
+        </Tooltip>
 
         <Tooltip label='View pending uploads'>
           <ActionIcon onClick={() => setOpen(true)} variant='filled' color='primary'>
@@ -38,55 +53,62 @@ export default function Files({ disableMediaPreview, exifEnabled, queryPage, com
           </ActionIcon>
         </Tooltip>
       </Group>
-      {favoritePages.isSuccess && favoritePages.data.length ? (
-        <Accordion
-          variant='contained'
-          mb='sm'
-          styles={(t) => ({
-            content: { backgroundColor: t.colorScheme === 'dark' ? t.colors.dark[7] : t.colors.gray[0] },
-            control: { backgroundColor: t.colorScheme === 'dark' ? t.colors.dark[7] : t.colors.gray[0] },
-          })}
-        >
-          <Accordion.Item value='favorite'>
-            <Accordion.Control>Favorite Files</Accordion.Control>
-            <Accordion.Panel>
-              <SimpleGrid cols={3} spacing='lg' breakpoints={[{ maxWidth: 'sm', cols: 1, spacing: 'sm' }]}>
-                {favoritePages.isSuccess && favoritePages.data.length
-                  ? favoritePages.data.map((image) => (
-                      <div key={image.id}>
-                        <File
-                          image={image}
-                          disableMediaPreview={disableMediaPreview}
-                          exifEnabled={exifEnabled}
-                          refreshImages={favoritePages.refetch}
-                          onDash={compress}
-                        />
-                      </div>
-                    ))
-                  : null}
-              </SimpleGrid>
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  paddingTop: 12,
-                  paddingBottom: 3,
-                }}
-              >
-                <Pagination total={favoriteNumPages} value={favoritePage} onChange={setFavoritePage} />
-              </Box>
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      ) : null}
 
-      <FilePagation
-        disableMediaPreview={disableMediaPreview}
-        exifEnabled={exifEnabled}
-        queryPage={queryPage}
-        compress={compress}
-      />
+      {listView ? (
+        <FileTable files={queryPage.data} />
+      ) : (
+        <div>
+          {favoritePages.isSuccess && favoritePages.data.length ? (
+            <Accordion
+              variant='contained'
+              mb='sm'
+              styles={(t) => ({
+                content: { backgroundColor: t.colorScheme === 'dark' ? t.colors.dark[7] : t.colors.gray[0] },
+                control: { backgroundColor: t.colorScheme === 'dark' ? t.colors.dark[7] : t.colors.gray[0] },
+              })}
+            >
+              <Accordion.Item value='favorite'>
+                <Accordion.Control>Favorite Files</Accordion.Control>
+                <Accordion.Panel>
+                  <SimpleGrid cols={3} spacing='lg' breakpoints={[{ maxWidth: 'sm', cols: 1, spacing: 'sm' }]}>
+                    {favoritePages.isSuccess && favoritePages.data.length
+                      ? favoritePages.data.map((image) => (
+                          <div key={image.id}>
+                            <File
+                              image={image}
+                              disableMediaPreview={disableMediaPreview}
+                              exifEnabled={exifEnabled}
+                              refreshImages={favoritePages.refetch}
+                              onDash={compress}
+                            />
+                          </div>
+                        ))
+                      : null}
+                  </SimpleGrid>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      paddingTop: 12,
+                      paddingBottom: 3,
+                    }}
+                  >
+                    <Pagination total={favoriteNumPages} value={favoritePage} onChange={setFavoritePage} />
+                  </Box>
+                </Accordion.Panel>
+              </Accordion.Item>
+            </Accordion>
+          ) : null}
+
+          <FilePagation
+            disableMediaPreview={disableMediaPreview}
+            exifEnabled={exifEnabled}
+            queryPage={queryPage}
+            compress={compress}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/src/lib/recoil/settings.ts
+++ b/src/lib/recoil/settings.ts
@@ -20,6 +20,7 @@ export type Settings = {
     users: boolean;
     invites: boolean;
     folders: boolean;
+    files: boolean;
   };
 };
 
@@ -30,6 +31,7 @@ export const DEFAULT_SETTINGS: Settings = {
     users: true,
     invites: true,
     folders: true,
+    files: true,
   },
 };
 
@@ -86,5 +88,15 @@ export const listViewFoldersSelector = selector<boolean>({
     set(settingsState, {
       showNonMedia: get(settingsState).showNonMedia,
       listView: { ...(get(settingsState).listView ?? DEFAULT_SETTINGS.listView), folders: newValue },
+    }),
+});
+
+export const listViewFilesSelector = selector<boolean>({
+  key: 'listViewFilesSelector',
+  get: ({ get }) => get(settingsState).listView?.files ?? DEFAULT_SETTINGS.listView.files,
+  set: ({ set, get }, newValue) =>
+    set(settingsState, {
+      showNonMedia: get(settingsState).showNonMedia,
+      listView: { ...(get(settingsState).listView ?? DEFAULT_SETTINGS.listView), files: newValue },
     }),
 });


### PR DESCRIPTION
This PR aims to add a table for the files (similar to folder/url). This would allow to sort e.g. for views and view the files in a more clear way. 

Here is a mockup of how I imagine it to look like:

![image](https://user-images.githubusercontent.com/1368405/233339480-e24772ee-aa9e-4b23-b69d-af8c22e0340f.png)


Sadly I'm no expert, so this is only a draft and does not work yet. 
I'm also not sure if this is the right way to implement such a feature, if not, please let me know!

@diced Could you maybe help me to finish this? Would really appreciate it!

I could also imagine a little image preview next to the name 