### PR TITLE
Sprinkled fixes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,8 +23,8 @@ services:
     env_file:
       - .env.local
     volumes:
-      - '$PWD/uploads:/zipline/uploads'
-      - '$PWD/public:/zipline/public'
+      - './uploads:/zipline/uploads'
+      - './public:/zipline/public'
     depends_on:
       - 'postgres'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - CORE_LOGGER=true
     volumes:
       - './uploads:/zipline/uploads'
-      - '$PWD/public:/zipline/public'
+      - './public:/zipline/public'
     depends_on:
       - 'postgres'
 

--- a/src/lib/middleware/getServerSideProps.ts
+++ b/src/lib/middleware/getServerSideProps.ts
@@ -61,7 +61,7 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (ct
       user_registration: config.features.user_registration,
       oauth_registration: config.features.oauth_registration,
       oauth_providers: JSON.stringify(oauth_providers),
-      bypass_local_login: config.oauth.bypass_local_login,
+      bypass_local_login: config.oauth?.bypass_local_login ?? false,
       chunks_size: config.chunks.chunks_size,
       max_size: config.chunks.max_size,
       totp_enabled: config.mfa.totp_enabled,

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -2,8 +2,10 @@ import { Button, Stack, Title, Tooltip } from '@mantine/core';
 import MutedText from 'components/MutedText';
 import Head from 'next/head';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 export default function FiveHundred() {
+  const { asPath } = useRouter();
   return (
     <>
       <Head>
@@ -24,9 +26,13 @@ export default function FiveHundred() {
         <Tooltip label={"Take a look at Zipline's logs and the browser console for more info"}>
           <MutedText>Internal server error</MutedText>
         </Tooltip>
-        <Button component={Link} href='/dashboard'>
-          Head to the Dashboard
-        </Button>
+        {asPath === '/dashboard' ? (
+          <Button onClick={() => window.location.reload()}>Attempt Refresh</Button>
+        ) : (
+          <Button component={Link} href='/dashboard'>
+            Head to the Dashboard
+          </Button>
+        )}
       </Stack>
     </>
   );


### PR DESCRIPTION
I've changed the compose file(s) to start using relative path rather than the $PWD variable. The rest of the commits should fix #397. The cause of this was due ot a previous PR that didn't check whether a config was null/undefined or not. The error page will now have a button to refresh if the error happened at `/dashboard`.