### PR TITLE
Fix webhook's thumbnail and image in the embed

### DIFF
--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -63,13 +63,13 @@ export async function sendUpload(user: User, file: File, raw_link: string, link:
             thumbnail:
               isImage && parsed.embed.thumbnail
                 ? {
-                    url: parsed.url,
+                    url: raw_link,
                   }
                 : null,
             image:
               isImage && parsed.embed.image
                 ? {
-                    url: parsed.url,
+                    url: raw_link,
                   }
                 : null,
           },

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -252,10 +252,12 @@ async function handler(req: NextApiReq, res: NextApiRes) {
       invis ? invis.invis : encodeURI(fileUpload.name)
     }`;
 
+    const embedUrl = `${domain}/r/${invis ? invis.invis : encodeURI(fileUpload.name)}`;
+
     response.files.push(responseUrl);
 
     if (zconfig.discord?.upload) {
-      await sendUpload(user, fileUpload, `${domain}/r/${invis ? invis.invis : fileUpload.name}`, responseUrl);
+      await sendUpload(user, fileUpload, `${domain}/r/${invis ? invis.invis : fileUpload.name}`, embedUrl);
     }
 
     if (zconfig.exif.enabled && zconfig.exif.remove_gps && fileUpload.mimetype.startsWith('image/')) {

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -252,12 +252,15 @@ async function handler(req: NextApiReq, res: NextApiRes) {
       invis ? invis.invis : encodeURI(fileUpload.name)
     }`;
 
-    const embedUrl = `${domain}/r/${invis ? invis.invis : encodeURI(fileUpload.name)}`;
-
     response.files.push(responseUrl);
 
     if (zconfig.discord?.upload) {
-      await sendUpload(user, fileUpload, `${domain}/r/${invis ? invis.invis : fileUpload.name}`, embedUrl);
+      await sendUpload(
+        user,
+        fileUpload,
+        `${domain}/r/${invis ? invis.invis : encodeURI(fileUpload.name)}`,
+        responseUrl
+      );
     }
 
     if (zconfig.exif.enabled && zconfig.exif.remove_gps && fileUpload.mimetype.startsWith('image/')) {


### PR DESCRIPTION
This will fix #390. The cause of this issue was due to using the `/view` endpoint which wasn't responding with only the image. It is likely that this was also caused by a change in how discord handled images/thumbnails in embeds if it had worked before.