### PR TITLE
Fix branding oversight caused by 0a34b0c

### DIFF
--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -167,7 +167,7 @@ export default function Login({
       <Center sx={{ height: '100vh' }}>
         <Card radius='md'>
           <Title size={30} align='left'>
-            {bypass_local_login ? ' Login to Zipline with' : 'Zipline'}
+            {bypass_local_login ? ` Login to ${title} with` : title}
           </Title>
 
           {oauth_registration && (


### PR DESCRIPTION
A simple PR to fix the login screen branding.