### PR TITLE
feat: og type for video

### DIFF
--- a/src/pages/view/[id].tsx
+++ b/src/pages/view/[id].tsx
@@ -128,6 +128,7 @@ export default function EmbeddedFile({
               </>
             )}
 
+            <meta property='og:type' content={'video.other'} />
             <meta property='og:url' content={`${host}/r/${file.name}`} />
             <meta property='og:video' content={`${host}/r/${file.name}`} />
             <meta property='og:video:url' content={`${host}/r/${file.name}`} />


### PR DESCRIPTION
# Description
This PR will add the missing `og:type` for videos.

[OG Docs Reference](https://ogp.me/#type_video.other)