### PR TITLE
Fix util method to check if variable is not null

### DIFF
--- a/src/lib/middleware/getServerSideProps.ts
+++ b/src/lib/middleware/getServerSideProps.ts
@@ -27,9 +27,15 @@ export type ServerSideProps = {
 };
 
 export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (ctx) => {
-  const ghEnabled = isNotNullOrUndefined(config.oauth?.github_client_id) && isNotNullOrUndefined(config.oauth?.github_client_secret);
-  const discEnabled = isNotNullOrUndefined(config.oauth?.discord_client_id) && isNotNullOrUndefined(config.oauth?.discord_client_secret);
-  const googleEnabled = isNotNullOrUndefined(config.oauth?.google_client_id) && isNotNullOrUndefined(config.oauth?.google_client_secret);
+  const ghEnabled =
+    isNotNullOrUndefined(config.oauth?.github_client_id) &&
+    isNotNullOrUndefined(config.oauth?.github_client_secret);
+  const discEnabled =
+    isNotNullOrUndefined(config.oauth?.discord_client_id) &&
+    isNotNullOrUndefined(config.oauth?.discord_client_secret);
+  const googleEnabled =
+    isNotNullOrUndefined(config.oauth?.google_client_id) &&
+    isNotNullOrUndefined(config.oauth?.google_client_secret);
 
   const oauth_providers: OauthProvider[] = [];
 

--- a/src/lib/middleware/getServerSideProps.ts
+++ b/src/lib/middleware/getServerSideProps.ts
@@ -1,5 +1,5 @@
 import config from 'lib/config';
-import { notNull } from 'lib/util';
+import { isNotNullOrUndefined } from 'lib/util';
 import { GetServerSideProps } from 'next';
 
 export type OauthProvider = {
@@ -27,9 +27,9 @@ export type ServerSideProps = {
 };
 
 export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (ctx) => {
-  const ghEnabled = notNull(config.oauth?.github_client_id, config.oauth?.github_client_secret);
-  const discEnabled = notNull(config.oauth?.discord_client_id, config.oauth?.discord_client_secret);
-  const googleEnabled = notNull(config.oauth?.google_client_id, config.oauth?.google_client_secret);
+  const ghEnabled = isNotNullOrUndefined(config.oauth?.github_client_id) && isNotNullOrUndefined(config.oauth?.github_client_secret);
+  const discEnabled = isNotNullOrUndefined(config.oauth?.discord_client_id) && isNotNullOrUndefined(config.oauth?.discord_client_secret);
+  const googleEnabled = isNotNullOrUndefined(config.oauth?.google_client_id) && isNotNullOrUndefined(config.oauth?.google_client_secret);
 
   const oauth_providers: OauthProvider[] = [];
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -120,6 +120,10 @@ export async function getBase64URLFromURL(url: string) {
   return `data:${res.headers.get('content-type')};base64,${base64}`;
 }
 
+export function isNotNullOrUndefined (value: unknown) {
+  return value !== null && value !== undefined;
+}
+
 export function notNull(a: unknown, b: unknown) {
   return a !== null && b !== null;
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -123,7 +123,3 @@ export async function getBase64URLFromURL(url: string) {
 export function isNotNullOrUndefined (value: unknown) {
   return value !== null && value !== undefined;
 }
-
-export function notNull(a: unknown, b: unknown) {
-  return a !== null && b !== null;
-}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -120,6 +120,6 @@ export async function getBase64URLFromURL(url: string) {
   return `data:${res.headers.get('content-type')};base64,${base64}`;
 }
 
-export function isNotNullOrUndefined (value: unknown) {
+export function isNotNullOrUndefined(value: unknown) {
   return value !== null && value !== undefined;
 }

--- a/src/pages/api/auth/oauth/discord.ts
+++ b/src/pages/api/auth/oauth/discord.ts
@@ -12,7 +12,10 @@ async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promi
       error: 'oauth registration is disabled',
     };
 
-  if (!isNotNullOrUndefined(config.oauth.discord_client_id) && !isNotNullOrUndefined(config.oauth.discord_client_secret)) {
+  if (
+    !isNotNullOrUndefined(config.oauth.discord_client_id) &&
+    !isNotNullOrUndefined(config.oauth.discord_client_secret)
+  ) {
     logger.error('Discord OAuth is not configured');
 
     return {

--- a/src/pages/api/auth/oauth/discord.ts
+++ b/src/pages/api/auth/oauth/discord.ts
@@ -3,7 +3,7 @@ import Logger from 'lib/logger';
 import { OAuthQuery, OAuthResponse, withOAuth } from 'lib/middleware/withOAuth';
 import { withZipline } from 'lib/middleware/withZipline';
 import { discord_auth } from 'lib/oauth';
-import { getBase64URLFromURL, notNull } from 'lib/util';
+import { getBase64URLFromURL, isNotNullOrUndefined } from 'lib/util';
 
 async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promise<OAuthResponse> {
   if (!config.features.oauth_registration)
@@ -12,7 +12,7 @@ async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promi
       error: 'oauth registration is disabled',
     };
 
-  if (!notNull(config.oauth.discord_client_id, config.oauth.discord_client_secret)) {
+  if (!isNotNullOrUndefined(config.oauth.discord_client_id) && !isNotNullOrUndefined(config.oauth.discord_client_secret)) {
     logger.error('Discord OAuth is not configured');
 
     return {

--- a/src/pages/api/auth/oauth/github.ts
+++ b/src/pages/api/auth/oauth/github.ts
@@ -12,7 +12,10 @@ async function handler({ code, state }: OAuthQuery, logger: Logger): Promise<OAu
       error: 'oauth registration is disabled',
     };
 
-  if (!isNotNullOrUndefined(config.oauth.github_client_id) && !isNotNullOrUndefined(config.oauth.github_client_secret)) {
+  if (
+    !isNotNullOrUndefined(config.oauth.github_client_id) &&
+    !isNotNullOrUndefined(config.oauth.github_client_secret)
+  ) {
     logger.error('GitHub OAuth is not configured');
     return {
       error_code: 401,

--- a/src/pages/api/auth/oauth/github.ts
+++ b/src/pages/api/auth/oauth/github.ts
@@ -3,7 +3,7 @@ import Logger from 'lib/logger';
 import { OAuthQuery, OAuthResponse, withOAuth } from 'lib/middleware/withOAuth';
 import { withZipline } from 'lib/middleware/withZipline';
 import { github_auth } from 'lib/oauth';
-import { getBase64URLFromURL, notNull } from 'lib/util';
+import { getBase64URLFromURL, isNotNullOrUndefined } from 'lib/util';
 
 async function handler({ code, state }: OAuthQuery, logger: Logger): Promise<OAuthResponse> {
   if (!config.features.oauth_registration)
@@ -12,7 +12,7 @@ async function handler({ code, state }: OAuthQuery, logger: Logger): Promise<OAu
       error: 'oauth registration is disabled',
     };
 
-  if (!notNull(config.oauth.github_client_id, config.oauth.github_client_secret)) {
+  if (!isNotNullOrUndefined(config.oauth.github_client_id) && !isNotNullOrUndefined(config.oauth.github_client_secret)) {
     logger.error('GitHub OAuth is not configured');
     return {
       error_code: 401,

--- a/src/pages/api/auth/oauth/google.ts
+++ b/src/pages/api/auth/oauth/google.ts
@@ -12,7 +12,10 @@ async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promi
       error: 'oauth registration is disabled',
     };
 
-  if (!isNotNullOrUndefined(config.oauth.google_client_id) && !isNotNullOrUndefined(config.oauth.google_client_secret)) {
+  if (
+    !isNotNullOrUndefined(config.oauth.google_client_id) &&
+    !isNotNullOrUndefined(config.oauth.google_client_secret)
+  ) {
     logger.error('Google OAuth is not configured');
     return {
       error_code: 401,

--- a/src/pages/api/auth/oauth/google.ts
+++ b/src/pages/api/auth/oauth/google.ts
@@ -3,7 +3,7 @@ import Logger from 'lib/logger';
 import { OAuthQuery, OAuthResponse, withOAuth } from 'lib/middleware/withOAuth';
 import { withZipline } from 'lib/middleware/withZipline';
 import { google_auth } from 'lib/oauth';
-import { getBase64URLFromURL, notNull } from 'lib/util';
+import { getBase64URLFromURL, isNotNullOrUndefined } from 'lib/util';
 
 async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promise<OAuthResponse> {
   if (!config.features.oauth_registration)
@@ -12,7 +12,7 @@ async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promi
       error: 'oauth registration is disabled',
     };
 
-  if (!notNull(config.oauth.google_client_id, config.oauth.google_client_secret)) {
+  if (!isNotNullOrUndefined(config.oauth.google_client_id) && !isNotNullOrUndefined(config.oauth.google_client_secret)) {
     logger.error('Google OAuth is not configured');
     return {
       error_code: 401,


### PR DESCRIPTION
When the serverside middleware checks to see if any of the oauth providers are enabled, it checks to see if the config is not null.
In node, the nullish operator `?` returns `undefined` instead of spewing a nasty error.

Config checks to see if it is not null.
```
> null === undefined
false
```

Fixes #457