### PR TITLE
Add support for generic OIDC OAuth provider like Authentik

### DIFF
--- a/prisma/migrations/20230926013510_oauth_add_generic/migration.sql
+++ b/prisma/migrations/20230926013510_oauth_add_generic/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "OauthProviders" ADD VALUE 'OIDC';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,7 @@ enum OauthProviders {
   DISCORD
   GITHUB
   GOOGLE
+  OIDC
 }
 
 model IncompleteFile {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -37,6 +37,7 @@ import {
   IconGraph,
   IconHome,
   IconLink,
+  IconLogin,
   IconLogout,
   IconReload,
   IconSettings,
@@ -137,6 +138,7 @@ export default function Layout({ children, props }) {
     GitHub: IconBrandGithubFilled,
     Discord: IconBrandDiscordFilled,
     Google: IconBrandGoogle,
+    OIDC: IconLogin,
   };
 
   for (const provider of oauth_providers) {

--- a/src/lib/config/Config.ts
+++ b/src/lib/config/Config.ts
@@ -138,6 +138,16 @@ export interface ConfigOAuth {
 
   google_client_id?: string;
   google_client_secret?: string;
+
+  oidc_client_id?: string;
+  oidc_client_secret?: string;
+  oidc_authorize_url?: string;
+  oidc_token_url?: string;
+  oidc_userinfo_url?: string;
+  oidc_scopes?: string;
+  oidc_name_field?: string;
+  oidc_user_id_field?: string;
+  oidc_provider_display_name?: string;
 }
 
 export interface ConfigChunks {

--- a/src/lib/config/readConfig.ts
+++ b/src/lib/config/readConfig.ts
@@ -150,6 +150,16 @@ export default function readConfig() {
     map('OAUTH_GOOGLE_CLIENT_ID', 'string', 'oauth.google_client_id'),
     map('OAUTH_GOOGLE_CLIENT_SECRET', 'string', 'oauth.google_client_secret'),
 
+    map('OAUTH_OIDC_CLIENT_ID', 'string', 'oauth.oidc_client_id'),
+    map('OAUTH_OIDC_CLIENT_SECRET', 'string', 'oauth.oidc_client_secret'),
+    map('OAUTH_OIDC_AUTHORIZE_URL', 'string', 'oauth.oidc_authorize_url'),
+    map('OAUTH_OIDC_TOKEN_URL', 'string', 'oauth.oidc_token_url'),
+    map('OAUTH_OIDC_USERINFO_URL', 'string', 'oauth.oidc_userinfo_url'),
+    map('OAUTH_OIDC_SCOPES', 'string', 'oauth.oidc_scopes'),
+    map('OAUTH_OIDC_NAME_FIELD', 'string', 'oauth.oidc_name_field'),
+    map('OAUTH_OIDC_USER_ID_FIELD', 'string', 'oauth.oidc_user_id_field'),
+    map('OAUTH_OIDC_PROVIDER_DISPLAY_NAME', 'string', 'oauth.oidc_provider_display_name'),
+
     map('FEATURES_INVITES', 'boolean', 'features.invites'),
     map('FEATURES_INVITES_LENGTH', 'number', 'features.invites_length'),
 

--- a/src/lib/config/validateConfig.ts
+++ b/src/lib/config/validateConfig.ts
@@ -179,6 +179,16 @@ const validator = s.object({
 
       google_client_id: s.string.nullable.default(null),
       google_client_secret: s.string.nullable.default(null),
+
+      oidc_client_id: s.string.nullable.default(null),
+      oidc_client_secret: s.string.nullable.default(null),
+      oidc_authorize_url: s.string.nullable.default(null),
+      oidc_token_url: s.string.nullable.default(null),
+      oidc_userinfo_url: s.string.nullable.default(null),
+      oidc_scopes: s.string.nullable.default(null),
+      oidc_name_field: s.string.nullable.default(null),
+      oidc_user_id_field: s.string.nullable.default(null),
+      oidc_provider_display_name: s.string.nullable.default(null),
     })
     .nullish.default(null),
   features: s

--- a/src/lib/middleware/getServerSideProps.ts
+++ b/src/lib/middleware/getServerSideProps.ts
@@ -37,6 +37,17 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (ct
     isNotNullOrUndefined(config.oauth?.google_client_id) &&
     isNotNullOrUndefined(config.oauth?.google_client_secret);
 
+  const oidcEnabled =
+    isNotNullOrUndefined(config.oauth.oidc_client_id) &&
+    isNotNullOrUndefined(config.oauth.oidc_client_secret) &&
+    isNotNullOrUndefined(config.oauth.oidc_authorize_url) &&
+    isNotNullOrUndefined(config.oauth.oidc_token_url) &&
+    isNotNullOrUndefined(config.oauth.oidc_userinfo_url) &&
+    isNotNullOrUndefined(config.oauth.oidc_scopes) &&
+    isNotNullOrUndefined(config.oauth.oidc_name_field) &&
+    isNotNullOrUndefined(config.oauth.oidc_user_id_field) &&
+    isNotNullOrUndefined(config.oauth.oidc_provider_display_name);
+
   const oauth_providers: OauthProvider[] = [];
 
   if (ghEnabled)
@@ -58,6 +69,15 @@ export const getServerSideProps: GetServerSideProps<ServerSideProps> = async (ct
       url: '/api/auth/oauth/google',
       link_url: '/api/auth/oauth/google?state=link',
     });
+
+  if (oidcEnabled)
+    oauth_providers.push({
+      name: config.oauth.oidc_provider_display_name,
+      url: '/api/auth/oauth/oidc',
+      link_url: '/api/auth/oauth/oidc?state=link',
+    });
+
+  console.log(oauth_providers);
 
   const obj = {
     props: {

--- a/src/lib/middleware/withOAuth.ts
+++ b/src/lib/middleware/withOAuth.ts
@@ -25,7 +25,7 @@ export interface OAuthResponse {
 
 export const withOAuth =
   (
-    provider: 'discord' | 'github' | 'google',
+    provider: 'discord' | 'github' | 'google' | 'oidc',
     oauth: (query: OAuthQuery, logger: Logger) => Promise<OAuthResponse>
   ) =>
   async (req: NextApiReq, res: NextApiRes) => {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -48,3 +48,21 @@ export const google_auth = {
     return res.json();
   },
 };
+
+export const oidc_auth = {
+  oauth_url: (authorizeUrl: string, clientId: string, origin: string, scope: string, state?: string) =>
+    `${authorizeUrl}?client_id=${clientId}&redirect_uri=${encodeURIComponent(
+      `${origin}/api/auth/oauth/oidc`
+    )}&response_type=code&access_type=offline&scope=${scope}${state ? `&state=${state}` : ''}`,
+  oauth_user: async (userinfoUrl: string, access_token: string) => {
+    const res = await fetch(`${userinfoUrl}`, {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    });
+    console.log('userinfo', res);
+    if (!res.ok) return null;
+
+    return res.json();
+  },
+};

--- a/src/pages/api/auth/oauth/oidc.ts
+++ b/src/pages/api/auth/oauth/oidc.ts
@@ -1,0 +1,82 @@
+import config from 'lib/config';
+import Logger from 'lib/logger';
+import { OAuthQuery, OAuthResponse, withOAuth } from 'lib/middleware/withOAuth';
+import { withZipline } from 'lib/middleware/withZipline';
+import { oidc_auth } from 'lib/oauth';
+import { isNotNullOrUndefined } from 'lib/util';
+
+async function handler({ code, state, host }: OAuthQuery, logger: Logger): Promise<OAuthResponse> {
+  if (!config.features.oauth_registration)
+    return {
+      error_code: 403,
+      error: 'oauth registration is disabled',
+    };
+
+  if (
+    !isNotNullOrUndefined(config.oauth.oidc_client_id) &&
+    !isNotNullOrUndefined(config.oauth.oidc_client_secret) &&
+    !isNotNullOrUndefined(config.oauth.oidc_authorize_url) &&
+    !isNotNullOrUndefined(config.oauth.oidc_token_url) &&
+    !isNotNullOrUndefined(config.oauth.oidc_userinfo_url) &&
+    !isNotNullOrUndefined(config.oauth.oidc_scopes) &&
+    !isNotNullOrUndefined(config.oauth.oidc_name_field) &&
+    !isNotNullOrUndefined(config.oauth.oidc_user_id_field) &&
+    !isNotNullOrUndefined(config.oauth.oidc_provider_display_name)
+  ) {
+    logger.error('OIDC OAuth is not configured');
+    return {
+      error_code: 401,
+      error: 'OIDC OAuth is not configured',
+    };
+  }
+
+  if (!code) {
+    return {
+      redirect: oidc_auth.oauth_url(
+        config.oauth.oidc_authorize_url,
+        config.oauth.oidc_client_id,
+        `${config.core.return_https ? 'https' : 'http'}://${host}`,
+        config.oauth.oidc_scopes,
+        state
+      ),
+    };
+  }
+
+  const body = new URLSearchParams({
+    code,
+    client_id: config.oauth.oidc_client_id,
+    client_secret: config.oauth.oidc_client_secret,
+    redirect_uri: `${config.core.return_https ? 'https' : 'http'}://${host}/api/auth/oauth/oidc`,
+    grant_type: 'authorization_code',
+  });
+
+  const resp = await fetch(config.oauth.oidc_token_url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  const text = await resp.text();
+  console.log(`oauth ${config.oauth.oidc_token_url} -> body(${body}) resp(${text})`);
+
+  if (!resp.ok) return { error: 'invalid request' };
+
+  const json = JSON.parse(text);
+
+  if (!json.access_token) return { error: 'no access_token in response' };
+
+  const userJson = await oidc_auth.oauth_user(config.oauth.oidc_userinfo_url, json.access_token);
+
+  if (!userJson) return { error: 'invalid user request' };
+
+  return {
+    username: userJson[config.oauth.oidc_name_field],
+    user_id: userJson[config.oauth.oidc_user_id_field],
+    access_token: json.access_token,
+    refresh_token: json.refresh_token,
+  };
+}
+
+export default withZipline(withOAuth('oidc', handler));

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -14,7 +14,7 @@ import {
   Title,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { IconBrandDiscordFilled, IconBrandGithub, IconBrandGoogle } from '@tabler/icons-react';
+import { IconBrandDiscordFilled, IconBrandGithub, IconBrandGoogle, IconLogin } from '@tabler/icons-react';
 import useFetch from 'hooks/useFetch';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -47,6 +47,7 @@ export default function Login({
     GitHub: IconBrandGithub,
     Discord: IconBrandDiscordFilled,
     Google: IconBrandGoogle,
+    OIDC: IconLogin,
   };
 
   for (const provider of oauth_providers) {


### PR DESCRIPTION
I was missing the option to use Authentik for authentication. Instead of making it specific, this should also give the option to use pretty much any compatible OIDC provider.

Pull request for documentation coming soon.