### PR TITLE
Fixed Discord Mobile Video Embeded Res Bug

### DIFF
--- a/src/pages/view/[id].tsx
+++ b/src/pages/view/[id].tsx
@@ -142,8 +142,6 @@ export default function EmbeddedFile({
             <meta property='og:video:url' content={`${host}/r/${file.name}`} />
             <meta property='og:video:secure_url' content={`${host}/r/${file.name}`} />
             <meta property='og:video:type' content={file.mimetype} />
-            <meta property='og:video:width' content='720' />
-            <meta property='og:video:height' content='480' />
           </>
         )}
         {file.mimetype.startsWith('audio') && (

--- a/src/pages/view/[id].tsx
+++ b/src/pages/view/[id].tsx
@@ -124,8 +124,6 @@ export default function EmbeddedFile({
             <meta name='twitter:card' content='player' />
             <meta name='twitter:player' content={`${host}/r/${file.name}`} />
             <meta name='twitter:player:stream' content={`${host}/r/${file.name}`} />
-            <meta name='twitter:player:width' content='720' />
-            <meta name='twitter:player:height' content='480' />
             <meta name='twitter:player:stream:content_type' content={file.mimetype} />
             <meta name='twitter:title' content={file.name} />
 


### PR DESCRIPTION
![before](https://github.com/diced/zipline/assets/88356593/23de2fe9-ae20-4871-8895-961b251cde25)
![After](https://github.com/diced/zipline/assets/88356593/f66067c0-cacb-428d-878b-bf907084375d)


Details: The Limited Embed Res On Discord Causes A Res Bug In Android Discord App 
The Fix Is Just To Remove The  ```<meta property='og:video:width' content='720' />
            <meta property='og:video:height' content='480' />``` and in the twitter card metatags too

fun fact twitter dosent have a res optimization like discord so the video embed wont be shown unless you let the twitter width one so i think this fix for discord only as it have res optimization 
            
Changes Was Made From src\pages\view\[id].tsx File

+ I Hope You Can Add An Auto res Fetch Feature To The Video Embed Like The Pics metatags One 