### PR TITLE
Add autohotkey file extension (.ahk) to mimes.json

### DIFF
--- a/mimes.json
+++ b/mimes.json
@@ -43,6 +43,8 @@
   ["afp", ["application/vnd.ibm.modcap"]],
   ["ahead", ["application/vnd.ahead.space"]],
   ["ahk", ["text/autohotkey"]],
+  ["ahk1", ["text/autohotkey"]],
+  ["ahk2", ["text/autohotkey"]],
   ["ai", ["application/postscript"]],
   ["aif", ["audio/aiff"]],
   ["aifc", ["audio/aiff"]],

--- a/mimes.json
+++ b/mimes.json
@@ -42,6 +42,7 @@
   ["afm", ["application/octet-stream"]],
   ["afp", ["application/vnd.ibm.modcap"]],
   ["ahead", ["application/vnd.ahead.space"]],
+  ["ahk", ["text/autohotkey"]],
   ["ai", ["application/postscript"]],
   ["aif", ["audio/aiff"]],
   ["aifc", ["audio/aiff"]],


### PR DESCRIPTION
This pull request simply adds the `.ahk` file extension used by [AutoHotkey](https://www.autohotkey.com/) scripts to the `mimes.json` file.