### PR TITLE
fix: incorrect password autocompletes

### DIFF
--- a/src/components/file/DashboardFile/EditFileDetailsModal.tsx
+++ b/src/components/file/DashboardFile/EditFileDetailsModal.tsx
@@ -142,6 +142,7 @@ export default function EditFileDetailsModal({
             label='Password'
             description='Set a password for these files. Leave blank to disable password protection.'
             value={password ?? ''}
+            autoComplete='off'
             onChange={(event) =>
               setPassword(event.currentTarget.value.trim() === '' ? null : event.currentTarget.value.trim())
             }

--- a/src/components/file/DashboardFileType.tsx
+++ b/src/components/file/DashboardFileType.tsx
@@ -83,13 +83,7 @@ export default function DashboardFileType({
     return <Placeholder text={`Click to view file ${file.name}`} Icon={icon[type] ?? IconFileUnknown} />;
 
   if (dbFile && file.password === true && !show)
-    return (
-      <Placeholder
-        text={`Click to view protected ${file.name}`}
-        Icon={IconShieldLockFilled}
-        onClick={() => window.open(`/view/${file.name}${password ? `?pw=${password}` : ''}`)}
-      />
-    );
+    return <Placeholder text={`Click to view protected ${file.name}`} Icon={IconShieldLockFilled} />;
 
   if (dbFile && file.password === true && show)
     return (

--- a/src/components/pages/settings/parts/SettingsUser.tsx
+++ b/src/components/pages/settings/parts/SettingsUser.tsx
@@ -122,6 +122,7 @@ export default function SettingsUser() {
         <PasswordInput
           label='Password'
           description='Leave blank to keep the same password'
+          autoComplete='new-password'
           {...form.getInputProps('password')}
           leftSection={<IconAsteriskSimple size='1rem' />}
         />

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -225,6 +225,7 @@ export default function UploadOptionsButton({ numFiles }: { numFiles: number }) 
             description='Set a password for these files. Leave blank to disable password protection. This value is not saved to your browser, and is cleared after uploading.'
             leftSection={<IconKey size='1rem' />}
             value={ephemeral.password ?? ''}
+            autoComplete='off'
             onChange={(event) =>
               setEphemeral(
                 'password',
@@ -233,7 +234,7 @@ export default function UploadOptionsButton({ numFiles }: { numFiles: number }) 
             }
           />
 
-          <Text color='dimmed' size='sm'>
+          <Text c='dimmed' size='sm'>
             <b>Other Options</b>
           </Text>
 

--- a/src/components/pages/urls/index.tsx
+++ b/src/components/pages/urls/index.tsx
@@ -144,6 +144,7 @@ export default function DashboardURLs() {
             <PasswordInput
               label='Password'
               description='Protect your link with a password'
+              autoComplete='off'
               {...form.getInputProps('password')}
             />
 

--- a/src/components/pages/users/EditUserModal.tsx
+++ b/src/components/pages/users/EditUserModal.tsx
@@ -170,6 +170,7 @@ export default function EditUserModal({
             <PasswordInput
               label='Password'
               placeholder='Enter a password...'
+              autoComplete='new-password'
               {...form.getInputProps('password')}
             />
             <FileInput

--- a/src/components/pages/users/index.tsx
+++ b/src/components/pages/users/index.tsx
@@ -106,6 +106,7 @@ export default function DashboardUsers() {
             <PasswordInput
               label='Password'
               placeholder='Enter a password...'
+              autoComplete='new-password'
               {...form.getInputProps('password')}
             />
             <FileInput

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -100,7 +100,7 @@ export default function Register({ config, invite }: InferGetServerSidePropsType
             </div>
           )}
 
-          <Text size='sm' color='dimmed'>
+          <Text size='sm' c='dimmed'>
             Create an account to get started.
           </Text>
 


### PR DESCRIPTION
Also fixed a small inconsistency with opening files. Password protected ones would open in a new tab immediately, others not. Let me know if this was intended...