### PR TITLE
fix: proper json parsing in flameshot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To upload files using flameshot we will use a script. Replace $TOKEN and $HOST w
 DATE=$(date '+%h_%Y_%d_%I_%m_%S.png');
 flameshot gui -r > ~/Pictures/$DATE;
 
-curl -H "Content-Type: multipart/form-data" -H "authorization: $TOKEN" -F file=@$1 $HOST/api/upload | jq -r 'files[0].url' | xsel -ib
+curl -H "Content-Type: multipart/form-data" -H "authorization: $TOKEN" -F file=@$1 $HOST/api/upload | jq -r '.files[0]' | xsel -ib
 ```
 
 # Contributing


### PR DESCRIPTION
This PR  fixes the JSON parsing in the example Flameshot script. 
The previous example would just return a `jq` compile error:
```sh
jq: error: files/0 is not defined at <top-level>, line 1:
files[0].url
jq: 1 compile error
```