### PR TITLE
fix: audio & video scrubbing

### DIFF
--- a/src/server/decorators/dbFile.ts
+++ b/src/server/decorators/dbFile.ts
@@ -21,7 +21,7 @@ function dbFileDecorator(fastify: FastifyInstance, _, done) {
     this.header('Content-Length', size);
     this.header('Content-Type', download ? 'application/octet-stream' : file.mimetype);
     this.header('Content-Disposition', `inline; filename="${encodeURI(file.originalName || file.name)}"`);
-    if (file.mimetype.startsWith('video/')) {
+    if (file.mimetype.startsWith('video/') || file.mimetype.startsWith('audio/')) {
       this.header('Accept-Ranges', 'bytes');
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
       this.header('Content-Range', `bytes 0-${size - 1}/${size}`);

--- a/src/server/decorators/dbFile.ts
+++ b/src/server/decorators/dbFile.ts
@@ -21,6 +21,11 @@ function dbFileDecorator(fastify: FastifyInstance, _, done) {
     this.header('Content-Length', size);
     this.header('Content-Type', download ? 'application/octet-stream' : file.mimetype);
     this.header('Content-Disposition', `inline; filename="${encodeURI(file.originalName || file.name)}"`);
+    if (file.mimetype.startsWith('video/')) {
+      this.header('Accept-Ranges', 'bytes');
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range
+      this.header('Content-Range', `bytes 0-${size - 1}/${size}`);
+    }
 
     return this.send(data);
   }


### PR DESCRIPTION
hey. previously, you couldn't scrub/seek videos uploaded.
this pull request fixes that.
it adds the missing headers that were required.

before: <video src="https://github.com/user-attachments/assets/51f5f34e-96ee-4815-9b41-8d3d378f35e1" />

after: <video src="https://github.com/user-attachments/assets/75043525-c734-4c08-b53a-5ca666017f62" />