### PR TITLE
Added a check for username length

### DIFF
--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -21,6 +21,8 @@ export default function Register({ code = undefined, title, user_registration })
   const [verifyPasswordError, setVerifyPasswordError] = useState('');
   const [strength, setStrength] = useState(0);
 
+  const MAX_USERNAME_LENGTH = 16;
+
   const setUser = useSetRecoilState(userSelector);
   const router = useRouter();
 
@@ -29,6 +31,11 @@ export default function Register({ code = undefined, title, user_registration })
 
   const checkUsername = async () => {
     setUsername(username.trim());
+
+    if (username.length > MAX_USERNAME_LENGTH) {
+      setUsernameError(`Username cannot exceed ${MAX_USERNAME_LENGTH} characters`);
+      return;
+    }
 
     setUsernameError('');
 
@@ -39,6 +46,7 @@ export default function Register({ code = undefined, title, user_registration })
       setUsernameError('');
     }
   };
+
 
   const checkPassword = () => {
     setVerifyPasswordError('');
@@ -101,7 +109,14 @@ export default function Register({ code = undefined, title, user_registration })
               <TextInput
                 label='Username'
                 value={username}
-                onChange={(e) => setUsername(e.target.value)}
+                onChange={(e) => {
+                  setUsername(e.target.value);
+                  if (e.target.value.length > MAX_USERNAME_LENGTH) {
+                    setUsernameError(`Username cannot exceed ${MAX_USERNAME_LENGTH} characters`);
+                  } else {
+                    setUsernameError('');
+                  }
+                }}
                 error={usernameError}
                 onBlur={() => checkUsername()}
               />

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -47,7 +47,6 @@ export default function Register({ code = undefined, title, user_registration })
     }
   };
 
-
   const checkPassword = () => {
     setVerifyPasswordError('');
     setPassword(password.trim());


### PR DESCRIPTION
During registration, there was previously no validation for the length of the username. I've added a constant in the /auth/register.tsx that dictates the maximum length of a given username, but it would probably be best to create a config option for it.