### PR TITLE
fix: code scroll overflow handling

### DIFF
--- a/src/components/render/PrismCode.tsx
+++ b/src/components/render/PrismCode.tsx
@@ -15,7 +15,7 @@ export default function PrismCode({ code, ext, ...props }) {
 
   return (
     <Prism
-      sx={(t) => ({ height: '100vh', backgroundColor: t.colors.dark[8] })}
+      sx={(t) => ({ height: '100vh', overflow: 'scroll', backgroundColor: t.colors.dark[8] })}
       withLineNumbers
       language={exts[ext]?.toLowerCase()}
       {...props}

--- a/src/pages/code/[id].tsx
+++ b/src/pages/code/[id].tsx
@@ -58,7 +58,7 @@ export default function Code({ code, id, title, render, renderType }) {
 
       {!render && (
         <PrismCode
-          sx={(t) => ({ height: '100vh', backgroundColor: t.colors.dark[8] })}
+          sx={(t) => ({ height: '100vh', overflow: 'scroll', backgroundColor: t.colors.dark[8] })}
           code={code}
           ext={id.split('.').pop()}
         />
@@ -66,7 +66,7 @@ export default function Code({ code, id, title, render, renderType }) {
 
       {render && overrideRender && (
         <PrismCode
-          sx={(t) => ({ height: '100vh', backgroundColor: t.colors.dark[8] })}
+          sx={(t) => ({ height: '100vh', overflow: 'scroll', backgroundColor: t.colors.dark[8] })}
           code={code}
           ext={id.split('.').pop()}
         />


### PR DESCRIPTION
Before, when opening something like `/code/CwYd1I.txt`, it shows:

![Zipline broken scroll](https://github.com/user-attachments/assets/b20380e0-132e-4a01-8f6a-d42a80e1147f)

Now, with the `overflow: scroll`, it shows:

![Zipline correct scroll](https://github.com/user-attachments/assets/5f1a3c52-48c8-4e89-9898-bbef348f81e3)
