### PR TITLE
Add checks variable modifiers

### DIFF
--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -50,7 +50,7 @@ export function parseString(str: string, value: ParseValue) {
   };
 
   const re =
-    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>\w+))?((::(?<mod_tzlocale>\S+))|(?<mod_check>\[(?<mod_check_true>".*")\|\|(?<mod_check_false>".*")\]))?\}/gi;
+    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>(\w+|<|<=|=|>=|>|\^|\$|~|\/)+))?((::(?<mod_tzlocale>\S+))|(?<mod_check>\[(?<mod_check_true>".*")\|\|(?<mod_check_false>".*")\]))?\}/gi;
   let matches: RegExpMatchArray | null;
 
   while ((matches = re.exec(str))) {
@@ -207,10 +207,10 @@ function modifier(
         return toHex(value);
       case mod == 'string':
         return value;
-      case mod.startsWith('equal'): {
+      case mod.startsWith('='): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
 
-        const check = mod.replace('equal', '');
+        const check = mod.replace('=', '');
 
         if (!check) return `{unknown_str_modifier(${mod})}`;
 
@@ -222,10 +222,10 @@ function modifier(
 
         return value.toLowerCase() == check ? check_true : check_false;
       }
-      case mod.startsWith('startswith'): {
+      case mod.startsWith('$'): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
 
-        const check = mod.replace('startswith', '');
+        const check = mod.replace('$', '');
 
         if (!check) return `{unknown_str_modifier(${mod})}`;
 
@@ -237,10 +237,10 @@ function modifier(
 
         return value.toLowerCase().startsWith(check) ? check_true : check_false;
       }
-      case mod.startsWith('endswith'): {
+      case mod.startsWith('^'): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
 
-        const check = mod.replace('endswith', '');
+        const check = mod.replace('^', '');
 
         if (!check) return `{unknown_str_modifier(${mod})}`;
 
@@ -252,10 +252,10 @@ function modifier(
 
         return value.toLowerCase().endsWith(check) ? check_true : check_false;
       }
-      case mod.startsWith('includes'): {
+      case mod.startsWith('~'): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
 
-        const check = mod.replace('includes', '');
+        const check = mod.replace('~', '');
 
         if (!check) return `{unknown_str_modifier(${mod})}`;
 
@@ -284,10 +284,10 @@ function modifier(
         return bytes(value);
       case mod == 'string':
         return value.toString();
-      case mod.startsWith('greaterequal'): {
+      case mod.startsWith('>='): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
 
-        const check = Number(mod.replace('greaterequal', ''));
+        const check = Number(mod.replace('>=', ''));
 
         if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
 
@@ -299,10 +299,10 @@ function modifier(
 
         return value >= check ? check_true : check_false;
       }
-      case mod.startsWith('greater'): {
+      case mod.startsWith('>'): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
 
-        const check = Number(mod.replace('greater', ''));
+        const check = Number(mod.replace('>', ''));
 
         if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
 
@@ -314,10 +314,10 @@ function modifier(
 
         return value > check ? check_true : check_false;
       }
-      case mod.startsWith('equal'): {
+      case mod.startsWith('='): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
 
-        const check = Number(mod.replace('equal', ''));
+        const check = Number(mod.replace('=', ''));
 
         if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
 
@@ -329,10 +329,10 @@ function modifier(
 
         return value == check ? check_true : check_false;
       }
-      case mod.startsWith('lesserequal'): {
+      case mod.startsWith('<='): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
 
-        const check = Number(mod.replace('lesserequal', ''));
+        const check = Number(mod.replace('<=', ''));
 
         if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
 
@@ -344,10 +344,10 @@ function modifier(
 
         return value <= check ? check_true : check_false;
       }
-      case mod.startsWith('lesser'): {
+      case mod.startsWith('<'): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
 
-        const check = Number(mod.replace('lesser', ''));
+        const check = Number(mod.replace('<', ''));
 
         if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
 

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -208,7 +208,8 @@ function modifier(
       case mod == 'string':
         return value;
       case mod.startsWith('='): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
 
         const check = mod.replace('=', '');
 
@@ -223,7 +224,8 @@ function modifier(
         return value.toLowerCase() == check ? check_true : check_false;
       }
       case mod.startsWith('$'): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
 
         const check = mod.replace('$', '');
 
@@ -238,7 +240,8 @@ function modifier(
         return value.toLowerCase().startsWith(check) ? check_true : check_false;
       }
       case mod.startsWith('^'): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
 
         const check = mod.replace('^', '');
 
@@ -253,7 +256,8 @@ function modifier(
         return value.toLowerCase().endsWith(check) ? check_true : check_false;
       }
       case mod.startsWith('~'): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
 
         const check = mod.replace('~', '');
 
@@ -285,7 +289,8 @@ function modifier(
       case mod == 'string':
         return value.toString();
       case mod.startsWith('>='): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
 
         const check = Number(mod.replace('>=', ''));
 
@@ -300,7 +305,8 @@ function modifier(
         return value >= check ? check_true : check_false;
       }
       case mod.startsWith('>'): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
 
         const check = Number(mod.replace('>', ''));
 
@@ -315,7 +321,8 @@ function modifier(
         return value > check ? check_true : check_false;
       }
       case mod.startsWith('='): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
 
         const check = Number(mod.replace('=', ''));
 
@@ -330,7 +337,8 @@ function modifier(
         return value == check ? check_true : check_false;
       }
       case mod.startsWith('<='): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
 
         const check = Number(mod.replace('<=', ''));
 
@@ -345,7 +353,8 @@ function modifier(
         return value <= check ? check_true : check_false;
       }
       case mod.startsWith('<'): {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
 
         const check = Number(mod.replace('<', ''));
 
@@ -373,7 +382,8 @@ function modifier(
       case mod == 'string':
         return value ? 'true' : 'false';
       case mod == 'istrue': {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_bool_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_bool_modifier(${mod})}`;
 
         if (_value) {
           return value
@@ -384,7 +394,8 @@ function modifier(
         return value ? check_true : check_false;
       }
       case mod == 'isfalse': {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_bool_modifier(${mod})}`;
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_bool_modifier(${mod})}`;
 
         if (_value) {
           return !value
@@ -398,8 +409,11 @@ function modifier(
         return `{unknown_bool_modifier(${mod})}`;
     }
   }
-  
-  if (typeof check_false == 'string' && ['>', '>=','=', '<=', '<', '~', '$', '^'].some(modif => mod.startsWith(modif))) {
+
+  if (
+    typeof check_false == 'string' &&
+    ['>', '>=', '=', '<=', '<', '~', '$', '^'].some((modif) => mod.startsWith(modif))
+  ) {
     if (_value) return parseString(check_false, _value) || check_false;
     return check_false;
   }

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -50,7 +50,7 @@ export function parseString(str: string, value: ParseValue) {
   };
 
   const re =
-    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>\w+))?(::(?<mod_tzlocale>\S+))?\}/gi;
+    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>\w+))?((::(?<mod_tzlocale>\S+))|(?<mod_check>\[(?<mod_check_true>".*")\|\|(?<mod_check_false>".*")\]))?\}/gi;
   let matches: RegExpMatchArray | null;
 
   while ((matches = re.exec(str))) {
@@ -59,6 +59,7 @@ export function parseString(str: string, value: ParseValue) {
     const index = matches.index as number;
 
     const getV = value[matches.groups.type as keyof ParseValue];
+
     if (!getV) {
       str = replaceCharsFromString(str, '{unknown_type}', index, re.lastIndex);
       re.lastIndex = index;
@@ -94,7 +95,14 @@ export function parseString(str: string, value: ParseValue) {
     if (matches.groups.mod) {
       str = replaceCharsFromString(
         str,
-        modifier(matches.groups.mod, v, matches.groups.mod_tzlocale ?? undefined),
+        modifier(
+          matches.groups.mod,
+          v,
+          matches.groups.mod_tzlocale ?? undefined,
+          matches.groups.mod_check_true ?? undefined,
+          matches.groups.mod_check_false ?? undefined,
+          value,
+        ),
         index,
         re.lastIndex,
       );
@@ -109,8 +117,17 @@ export function parseString(str: string, value: ParseValue) {
   return str;
 }
 
-function modifier(mod: string, value: unknown, tzlocale?: string): string {
+function modifier(
+  mod: string,
+  value: unknown,
+  tzlocale?: string,
+  check_true?: string,
+  check_false?: string,
+  _value?: ParseValue,
+): string {
   mod = mod.toLowerCase();
+  check_true = check_true?.slice(1, -1);
+  check_false = check_false?.slice(1, -1);
 
   if (value instanceof Date) {
     const args: [string?, { timeZone: string }?] = [undefined, undefined];
@@ -173,56 +190,223 @@ function modifier(mod: string, value: unknown, tzlocale?: string): string {
         return `{unknown_date_modifier(${mod})}`;
     }
   } else if (typeof value === 'string') {
-    switch (mod) {
-      case 'upper':
+    switch (true) {
+      case mod == 'upper':
         return value.toUpperCase();
-      case 'lower':
+      case mod == 'lower':
         return value.toLowerCase();
-      case 'title':
+      case mod == 'title':
         return value.charAt(0).toUpperCase() + value.slice(1);
-      case 'length':
+      case mod == 'length':
         return value.length.toString();
-      case 'reverse':
+      case mod == 'reverse':
         return value.split('').reverse().join('');
-      case 'base64':
+      case mod == 'base64':
         return btoa(value);
-      case 'hex':
+      case mod == 'hex':
         return toHex(value);
-      case 'string':
+      case mod == 'string':
         return value;
+      case mod.startsWith('equal'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('equal', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase() == check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase() == check ? check_true : check_false;
+      }
+      case mod.startsWith('startswith'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('startswith', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase().startsWith(check)
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase().startsWith(check) ? check_true : check_false;
+      }
+      case mod.startsWith('endswith'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('endswith', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase().endsWith(check)
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase().endsWith(check) ? check_true : check_false;
+      }
+      case mod.startsWith('includes'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('includes', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase().includes(check)
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase().includes(check) ? check_true : check_false;
+      }
       default:
         return `{unknown_str_modifier(${mod})}`;
     }
   } else if (typeof value === 'number') {
-    switch (mod) {
-      case 'comma':
+    switch (true) {
+      case mod == 'comma':
         return value.toLocaleString();
-      case 'hex':
+      case mod == 'hex':
         return value.toString(16);
-      case 'octal':
+      case mod == 'octal':
         return value.toString(8);
-      case 'binary':
+      case mod == 'binary':
         return value.toString(2);
-      case 'bytes':
+      case mod == 'bytes':
         return bytes(value);
-      case 'string':
+      case mod == 'string':
         return value.toString();
+      case mod.startsWith('greaterequal'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('greaterequal', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value >= check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value >= check ? check_true : check_false;
+      }
+      case mod.startsWith('greater'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('greater', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value > check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value > check ? check_true : check_false;
+      }
+      case mod.startsWith('equal'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('equal', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value == check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value == check ? check_true : check_false;
+      }
+      case mod.startsWith('lesserequal'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('lesserequal', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value <= check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value <= check ? check_true : check_false;
+      }
+      case mod.startsWith('lesser'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('lesser', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value < check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value < check ? check_true : check_false;
+      }
       default:
         return `{unknown_int_modifier(${mod})}`;
     }
   } else if (typeof value === 'boolean') {
-    switch (mod) {
-      case 'yesno':
+    switch (true) {
+      case mod == 'yesno':
         return value ? 'Yes' : 'No';
-      case 'onoff':
+      case mod == 'onoff':
         return value ? 'On' : 'Off';
-      case 'truefalse':
+      case mod == 'truefalse':
         return value ? 'True' : 'False';
-      case 'string':
+      case mod == 'string':
         return value ? 'true' : 'false';
+      case mod == 'istrue': {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_bool_modifier(${mod})}`;
+
+        if (_value) {
+          return value
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value ? check_true : check_false;
+      }
+      case mod == 'isfalse': {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string') return `{unknown_bool_modifier(${mod})}`;
+
+        if (_value) {
+          return !value
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return !value ? check_true : check_false;
+      }
       default:
         return `{unknown_bool_modifier(${mod})}`;
     }
+  }
+  
+  if (typeof check_false == 'string' && ['greater', 'greaterequal','equal', 'lesser', 'lesserequal'].some(modif => mod.startsWith(modif))) {
+    if (_value) return parseString(check_false, _value) || check_false;
+    return check_false;
+  }
+
+  if (typeof check_false == 'string' && ['istrue', 'isfalse'].includes(mod)) {
+    if (_value) return parseString(check_false, _value) || check_false;
+    return check_false;
   }
 
   return `{unknown_modifier(${mod})}`;

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -399,7 +399,7 @@ function modifier(
     }
   }
   
-  if (typeof check_false == 'string' && ['greater', 'greaterequal','equal', 'lesser', 'lesserequal'].some(modif => mod.startsWith(modif))) {
+  if (typeof check_false == 'string' && ['>', '>=','=', '<=', '<', '~', '$', '^'].some(modif => mod.startsWith(modif))) {
     if (_value) return parseString(check_false, _value) || check_false;
     return check_false;
   }


### PR DESCRIPTION
For `number`s:
- `>X`: Greater than X [^1]
- `>=X`: Greater or equal to X [^1]
- `=X`: Equal to X [^1]
- `<=X`: Lesser or equal to X [^1]
- `<X`: less than X [^1]
[^1]: X is any number

For `string`s:
- `=Y`: Equals to Y [^2]
- `~Y`: Contains/Includes Y [^2]
- `$Y`: Starts with Y [^2]
- `^Y`: Ends with Y [^2]
 [^2]: Y is any string

For `boolean`s:
`istrue`: Is true
`isfalse`: Is false

they work like so
`{type.prop::mod["true string"||"false string"]}`

Example:
`{file.maxViews::>0["{file.views}/{file.maxViews}"||""]}`
This will return
- `<views>`/`<max_views>` (eg. 2/7) when `maxViews` is greater than 0
- Nothing when it's `0`, less than `0` or `null`