### PR TITLE
fix: sharex url shortening config

### DIFF
--- a/src/components/pages/settings/parts/SettingsGenerators/generators/sharex.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/generators/sharex.tsx
@@ -22,7 +22,7 @@ export function sharex(token: string, type: 'file' | 'url', options: GeneratorOp
     config.RequestURL = `${window.location.origin}/api/user/urls`;
 
     delete (config as any).FileFormName;
-    (config as any).Data = JSON.stringify({ url: '{input}' });
+    (config as any).Data = JSON.stringify({ destination: '{input}' });
   }
 
   const toAddHeaders: UploadHeaders = {


### PR DESCRIPTION
V4 API requires destination, not url. This should fix the generated config for url shortening.