### PR TITLE
Add exists conditional modifier to date, fix parser regex

### DIFF
--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -155,37 +155,49 @@ function modifier(
       }
     }
 
-    switch (mod) {
-      case 'locale':
+    switch (true) {
+      case mod == 'locale':
         return value.toLocaleString(...args);
-      case 'time':
+      case mod == 'time':
         return value.toLocaleTimeString(...args);
-      case 'date':
+      case mod == 'date':
         return value.toLocaleDateString(...args);
-      case 'unix':
+      case mod == 'unix':
         return Math.floor(value.getTime() / 1000).toString();
-      case 'iso':
+      case mod == 'iso':
         return value.toISOString();
-      case 'utc':
+      case mod == 'utc':
         return value.toUTCString();
-      case 'year':
+      case mod == 'year':
         return value.getFullYear().toString();
-      case 'month':
+      case mod == 'month':
         return (value.getMonth() + 1).toString();
-      case 'day':
+      case mod == 'day':
         return value.getDate().toString();
-      case 'hour':
+      case mod == 'hour':
         return value.getHours().toString();
-      case 'minute':
+      case mod == 'minute':
         return value.getMinutes().toString();
-      case 'second':
+      case mod == 'second':
         return value.getSeconds().toString();
-      case 'string':
+      case mod == 'string':
         return value.toString();
-      case 'ampm':
+      case mod == 'ampm':
         return value.getHours() < 12 ? 'am' : 'pm';
-      case 'AMPM':
+      case mod == 'AMPM':
         return value.getHours() < 12 ? 'AM' : 'PM';
+      case mod == 'exists': {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_date_modifier(${mod})}`;
+
+        if (_value) {
+          return value
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value ? check_true : check_false;
+      }
       default:
         return `{unknown_date_modifier(${mod})}`;
     }
@@ -207,7 +219,7 @@ function modifier(
         return toHex(value);
       case mod == 'string':
         return value;
-      case mod.startsWith('exists'): {
+      case mod == 'exists': {
         if (typeof check_true !== 'string' || typeof check_false !== 'string')
           return `{unknown_str_modifier(${mod})}`;
 

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -50,7 +50,7 @@ export function parseString(str: string, value: ParseValue) {
   };
 
   const re =
-    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>(\w+|<|<=|=|>=|>|\^|\$|~|\/)+))?((::(?<mod_tzlocale>\S+))|(?<mod_check>\[(?<mod_check_true>".*")\|\|(?<mod_check_false>".*")\]))?\}/gi;
+    /{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>(\w+|<|<=|=|>=|>|\^|\$|~|\/)+))?((::(?<mod_tzlocale>\S+?))|(?<mod_check>\[(?<mod_check_true>".*?")\|\|(?<mod_check_false>".*?")\]))?\}/gi;
   let matches: RegExpMatchArray | null;
 
   while ((matches = re.exec(str))) {

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -50,7 +50,7 @@ export function parseString(str: string, value: ParseValue) {
   };
 
   const re =
-    /{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>(\w+|<|<=|=|>=|>|\^|\$|~|\/)+))?((::(?<mod_tzlocale>\S+?))|(?<mod_check>\[(?<mod_check_true>".*?")\|\|(?<mod_check_false>".*?")\]))?\}/gi;
+    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>(\w+|<|<=|=|>=|>|\^|\$|~|\/)+))?((::(?<mod_tzlocale>\S+?))|(?<mod_check>\[(?<mod_check_true>".*?")\|\|(?<mod_check_false>".*?")\]))?\}/gi;
   let matches: RegExpMatchArray | null;
 
   while ((matches = re.exec(str))) {

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -373,14 +373,6 @@ function modifier(
     }
   } else if (typeof value === 'boolean') {
     switch (true) {
-      case mod == 'yesno':
-        return value ? 'Yes' : 'No';
-      case mod == 'onoff':
-        return value ? 'On' : 'Off';
-      case mod == 'truefalse':
-        return value ? 'True' : 'False';
-      case mod == 'string':
-        return value ? 'true' : 'false';
       case mod == 'istrue': {
         if (typeof check_true !== 'string' || typeof check_false !== 'string')
           return `{unknown_bool_modifier(${mod})}`;

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -207,6 +207,18 @@ function modifier(
         return toHex(value);
       case mod == 'string':
         return value;
+      case mod.startsWith('exists'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value ? check_true : check_false;
+      }
       case mod.startsWith('='): {
         if (typeof check_true !== 'string' || typeof check_false !== 'string')
           return `{unknown_str_modifier(${mod})}`;
@@ -385,18 +397,6 @@ function modifier(
 
         return value ? check_true : check_false;
       }
-      case mod == 'isfalse': {
-        if (typeof check_true !== 'string' || typeof check_false !== 'string')
-          return `{unknown_bool_modifier(${mod})}`;
-
-        if (_value) {
-          return !value
-            ? parseString(check_true, _value) || check_true
-            : parseString(check_false, _value) || check_false;
-        }
-
-        return !value ? check_true : check_false;
-      }
       default:
         return `{unknown_bool_modifier(${mod})}`;
     }
@@ -410,7 +410,7 @@ function modifier(
     return check_false;
   }
 
-  if (typeof check_false == 'string' && ['istrue', 'isfalse'].includes(mod)) {
+  if (typeof check_false == 'string' && ['istrue', 'isfalse', 'exists'].includes(mod)) {
     if (_value) return parseString(check_false, _value) || check_false;
     return check_false;
   }

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -50,7 +50,7 @@ export function parseString(str: string, value: ParseValue) {
   };
 
   const re =
-    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>\w+))?(::(?<mod_tzlocale>\S+))?\}/gi;
+    /\{(?<type>file|url|user|debug|link|metricsUser|metricsZipline)\.(?<prop>\w+)(::(?<mod>(\w+|<|<=|=|>=|>|\^|\$|~|\/)+))?((::(?<mod_tzlocale>\S+))|(?<mod_check>\[(?<mod_check_true>".*")\|\|(?<mod_check_false>".*")\]))?\}/gi;
   let matches: RegExpMatchArray | null;
 
   while ((matches = re.exec(str))) {
@@ -59,6 +59,7 @@ export function parseString(str: string, value: ParseValue) {
     const index = matches.index as number;
 
     const getV = value[matches.groups.type as keyof ParseValue];
+
     if (!getV) {
       str = replaceCharsFromString(str, '{unknown_type}', index, re.lastIndex);
       re.lastIndex = index;
@@ -94,7 +95,14 @@ export function parseString(str: string, value: ParseValue) {
     if (matches.groups.mod) {
       str = replaceCharsFromString(
         str,
-        modifier(matches.groups.mod, v, matches.groups.mod_tzlocale ?? undefined),
+        modifier(
+          matches.groups.mod,
+          v,
+          matches.groups.mod_tzlocale ?? undefined,
+          matches.groups.mod_check_true ?? undefined,
+          matches.groups.mod_check_false ?? undefined,
+          value,
+        ),
         index,
         re.lastIndex,
       );
@@ -109,8 +117,17 @@ export function parseString(str: string, value: ParseValue) {
   return str;
 }
 
-function modifier(mod: string, value: unknown, tzlocale?: string): string {
+function modifier(
+  mod: string,
+  value: unknown,
+  tzlocale?: string,
+  check_true?: string,
+  check_false?: string,
+  _value?: ParseValue,
+): string {
   mod = mod.toLowerCase();
+  check_true = check_true?.slice(1, -1);
+  check_false = check_false?.slice(1, -1);
 
   if (value instanceof Date) {
     const args: [string?, { timeZone: string }?] = [undefined, undefined];
@@ -173,56 +190,237 @@ function modifier(mod: string, value: unknown, tzlocale?: string): string {
         return `{unknown_date_modifier(${mod})}`;
     }
   } else if (typeof value === 'string') {
-    switch (mod) {
-      case 'upper':
+    switch (true) {
+      case mod == 'upper':
         return value.toUpperCase();
-      case 'lower':
+      case mod == 'lower':
         return value.toLowerCase();
-      case 'title':
+      case mod == 'title':
         return value.charAt(0).toUpperCase() + value.slice(1);
-      case 'length':
+      case mod == 'length':
         return value.length.toString();
-      case 'reverse':
+      case mod == 'reverse':
         return value.split('').reverse().join('');
-      case 'base64':
+      case mod == 'base64':
         return btoa(value);
-      case 'hex':
+      case mod == 'hex':
         return toHex(value);
-      case 'string':
+      case mod == 'string':
         return value;
+      case mod.startsWith('='): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('=', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase() == check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase() == check ? check_true : check_false;
+      }
+      case mod.startsWith('$'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('$', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase().startsWith(check)
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase().startsWith(check) ? check_true : check_false;
+      }
+      case mod.startsWith('^'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('^', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase().endsWith(check)
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase().endsWith(check) ? check_true : check_false;
+      }
+      case mod.startsWith('~'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_str_modifier(${mod})}`;
+
+        const check = mod.replace('~', '');
+
+        if (!check) return `{unknown_str_modifier(${mod})}`;
+
+        if (_value) {
+          return value.toLowerCase().includes(check)
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value.toLowerCase().includes(check) ? check_true : check_false;
+      }
       default:
         return `{unknown_str_modifier(${mod})}`;
     }
   } else if (typeof value === 'number') {
-    switch (mod) {
-      case 'comma':
+    switch (true) {
+      case mod == 'comma':
         return value.toLocaleString();
-      case 'hex':
+      case mod == 'hex':
         return value.toString(16);
-      case 'octal':
+      case mod == 'octal':
         return value.toString(8);
-      case 'binary':
+      case mod == 'binary':
         return value.toString(2);
-      case 'bytes':
+      case mod == 'bytes':
         return bytes(value);
-      case 'string':
+      case mod == 'string':
         return value.toString();
+      case mod.startsWith('>='): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('>=', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value >= check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value >= check ? check_true : check_false;
+      }
+      case mod.startsWith('>'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('>', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value > check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value > check ? check_true : check_false;
+      }
+      case mod.startsWith('='): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('=', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value == check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value == check ? check_true : check_false;
+      }
+      case mod.startsWith('<='): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('<=', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value <= check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value <= check ? check_true : check_false;
+      }
+      case mod.startsWith('<'): {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_int_modifier(${mod})}`;
+
+        const check = Number(mod.replace('<', ''));
+
+        if (Number.isNaN(check)) return `{unknown_int_modifier(${mod})}`;
+
+        if (_value) {
+          return value < check
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value < check ? check_true : check_false;
+      }
       default:
         return `{unknown_int_modifier(${mod})}`;
     }
   } else if (typeof value === 'boolean') {
-    switch (mod) {
-      case 'yesno':
+    switch (true) {
+      case mod == 'yesno':
         return value ? 'Yes' : 'No';
-      case 'onoff':
+      case mod == 'onoff':
         return value ? 'On' : 'Off';
-      case 'truefalse':
+      case mod == 'truefalse':
         return value ? 'True' : 'False';
-      case 'string':
+      case mod == 'string':
         return value ? 'true' : 'false';
+      case mod == 'istrue': {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_bool_modifier(${mod})}`;
+
+        if (_value) {
+          return value
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return value ? check_true : check_false;
+      }
+      case mod == 'isfalse': {
+        if (typeof check_true !== 'string' || typeof check_false !== 'string')
+          return `{unknown_bool_modifier(${mod})}`;
+
+        if (_value) {
+          return !value
+            ? parseString(check_true, _value) || check_true
+            : parseString(check_false, _value) || check_false;
+        }
+
+        return !value ? check_true : check_false;
+      }
       default:
         return `{unknown_bool_modifier(${mod})}`;
     }
+  }
+
+  if (
+    typeof check_false == 'string' &&
+    ['>', '>=', '=', '<=', '<', '~', '$', '^'].some((modif) => mod.startsWith(modif))
+  ) {
+    if (_value) return parseString(check_false, _value) || check_false;
+    return check_false;
+  }
+
+  if (typeof check_false == 'string' && ['istrue', 'isfalse'].includes(mod)) {
+    if (_value) return parseString(check_false, _value) || check_false;
+    return check_false;
   }
 
   return `{unknown_modifier(${mod})}`;


### PR DESCRIPTION
since i noticed that `{file.deletesAt}` can be `null`, I added `::exists` modifier to `date`s too

also fixed parser regex, before this fix, here `{file.createdAt::locale::it-IT,Europe/Rome}{file.id}` it would match `it-IT,Europe/Rome}{file.id` as locale timezone

here `{file.name::exists["yes"||"no"]}{file.originalName::exists["yes"||"no"]}` it would match `"yes"||"no"]}{file.originalName::exists["yes"` as `mod_check_true` group

docs pr at [diced/zipline-docs#79](https://github.com/diced/zipline-docs/pull/79)