### PR TITLE
Quality of life improvements.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@ node_modules/
 .next/
 uploads/
 .git/
+!.git/refs
+!.git/HEAD
 .yarn/*
 !.yarn/releases
 !.yarn/plugins

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   push:
-    name: Push Image
+    name: Push Commit Image
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -22,7 +22,7 @@ jobs:
       - name: Get version
         id: version
         run: |
-          echo "zipline_version=$(jq .version package.json -r)" >> $GITHUB_OUTPUT
+          echo "zipline_commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
@@ -51,8 +51,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/diced/zipline:v3-trunk
-            ghcr.io/diced/zipline:v3-trunk-${{ steps.version.outputs.zipline_version }}
+            ghcr.io/diced/zipline:v3-trunk-${{ steps.version.outputs.zipline_commit }}
             ${{ secrets.DOCKERHUB_USERNAME }}/zipline:v3-trunk
-            ${{ secrets.DOCKERHUB_USERNAME }}/zipline:v3-trunk-${{ steps.version.outputs.zipline_version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/zipline:v3-trunk-${{ steps.version.outputs.zipline_commit }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ ENV PRISMA_QUERY_ENGINE_BINARY=/prisma-engines/query-engine \
   ZIPLINE_DOCKER_BUILD=true \
   NEXT_TELEMETRY_DISABLED=1
 
+COPY .git/refs ./.git/refs
+COPY .git/HEAD ./.git/HEAD
+
 
 # Copy only the necessary files from the previous stage
 COPY --from=builder /zipline/dist ./dist

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -316,7 +316,9 @@ export default function Layout({ children, props }) {
                   variant='dot'
                   color={version.data.update ? 'red' : 'primary'}
                 >
-                  {version.data.versions.current}
+                  {version.data.isUpstream
+                    ? version.data.versions.current.slice(0, 7)
+                    : version.data.versions.current}
                 </Badge>
               </Tooltip>
             </Navbar.Section>

--- a/src/components/pages/Manage/ClearStorage.tsx
+++ b/src/components/pages/Manage/ClearStorage.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 
 export default function ClearStorage({ open, setOpen }) {
   const [check, setCheck] = useState(false);
-  const handleDelete = async (datasource: boolean, orphaned?: boolean) => {
+  const handleDelete = async (orphaned?: boolean) => {
     showNotification({
       id: 'clear-uploads',
       title: 'Clearing...',
@@ -16,7 +16,7 @@ export default function ClearStorage({ open, setOpen }) {
       autoClose: false,
     });
 
-    const res = await useFetch('/api/admin/clear', 'POST', { datasource, orphaned });
+    const res = await useFetch('/api/admin/clear', 'POST', { orphaned });
 
     if (res.error) {
       updateNotification({
@@ -65,21 +65,13 @@ export default function ClearStorage({ open, setOpen }) {
           onClick={() => {
             setOpen(false);
             openConfirmModal({
-              title: 'Do you want to clear storage too?',
-              labels: { confirm: 'Yes', cancel: check ? 'Ok' : 'No' },
-              children: check && (
-                <Text size='sm' color='gray'>
-                  Due to clearing orphaned files, storage clearing will be unavailable.
-                </Text>
-              ),
-              confirmProps: { disabled: check },
+              title: 'Are you sure?',
+              confirmProps: { color: 'red' },
+              children: <Text size='sm'>This action is destructive and irreversible.</Text>,
+              labels: { confirm: 'Yes', cancel: 'No' },
               onConfirm: () => {
                 closeAllModals();
-                handleDelete(true);
-              },
-              onCancel: () => {
-                closeAllModals();
-                handleDelete(false, check);
+                handleDelete(check);
               },
               onClose: () => setCheck(false),
             });

--- a/src/pages/api/admin/clear.ts
+++ b/src/pages/api/admin/clear.ts
@@ -8,21 +8,23 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
   try {
     const { orphaned } = req.body;
     if (orphaned) {
+      const files = await prisma.file.findMany({
+        where: {
+          userId: null,
+        },
+      });
       const { count } = await prisma.file.deleteMany({
         where: {
           userId: null,
         },
       });
+      for (const file of files) await datasource.delete(file.name);
       logger.info(`User ${user.username} (${user.id}) cleared the database of ${count} orphaned files`);
       return res.json({ message: 'cleared storage (orphaned only)' });
     }
     const { count } = await prisma.file.deleteMany({});
+    await datasource.clear();
     logger.info(`User ${user.username} (${user.id}) cleared the database of ${count} files`);
-
-    if (req.body.datasource) {
-      await datasource.clear();
-      logger.info(`User ${user.username} (${user.id}) cleared storage`);
-    }
   } catch (e) {
     logger.error(`User ${user.username} (${user.id}) failed to clear the database or storage`);
     logger.error(e);

--- a/src/pages/api/admin/export.ts
+++ b/src/pages/api/admin/export.ts
@@ -283,14 +283,6 @@ async function handler(req: NextApiReq, res: NextApiRes, user: UserExtended) {
     };
   }
 
-  const stats = await prisma.stats.findMany();
-  for (const stat of stats) {
-    exportData.stats.push({
-      created_at: stat.createdAt.toISOString(),
-      data: stat.data,
-    });
-  }
-
   exportData.request.user = exportData.user_map[user.id];
 
   for (const folder of folders) {

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -3,7 +3,10 @@ import { NextApiReq, NextApiRes, withZipline } from 'middleware/withZipline';
 
 async function handler(_: NextApiReq, res: NextApiRes) {
   const users = await prisma.user.findMany();
-  for (let i = 0; i !== users.length; ++i) delete users[i].password;
+  for (let i = 0; i !== users.length; ++i) {
+    delete users[i].password;
+    delete users[i].uuid;
+  }
 
   return res.json(users);
 }

--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -5,24 +5,29 @@ import { NextApiReq, NextApiRes, withZipline } from 'middleware/withZipline';
 async function handler(_: NextApiReq, res: NextApiRes) {
   if (!config.website.show_version) return res.forbidden('version hidden');
 
-  const pkg = JSON.parse(await readFile('package.json', 'utf8'));
+  const pRev = await (async function () {
+    try {
+      return await readFile('.git/HEAD', 'utf8');
+    } catch (e) {
+      return JSON.parse(await readFile('package.json', 'utf8')).version;
+    }
+  })();
+  const { groups } = new RegExp(/^ref: (?<ref>(\w+\/?)*)/).exec(pRev) || { groups: null };
+  let rev: string;
 
-  const re = await fetch('https://zipline.diced.sh/api/version?c=' + pkg.version);
+  if (!groups) rev = pRev;
+  else rev = await readFile(`.git/${groups.ref}`, 'utf8');
+
+  const re = await fetch(`https://v3.zipline.diced.sh/api/version?c=?c=${rev}`);
   const json = await re.json();
 
+  if (!re.ok) return res.badRequest(json.error);
   let updateToType = 'stable';
-
-  if (json.isUpstream) {
-    updateToType = 'upstream';
-
-    if (json.update?.stable) {
-      updateToType = 'stable';
-    }
-  }
+  if (json.isUpstream) updateToType = 'upstream';
 
   return res.json({
-    isUpstream: true,
-    update: json.update?.stable || json.update?.upstream,
+    isUpstream: json.isUpstream,
+    update: json.isUpstream ? json.update?.upstream : json.update?.stable,
     updateToType,
     versions: {
       stable: json.git.stable,


### PR DESCRIPTION
Fix #718 due to exporting too many stats. Now the export will not include it due to no importing for it in v4.
Exclude a user's uuid from /api/users, You just need that and your instance's token to log in as any other user.
Apply a different method of version checking by using `.git/HEAD` (following referred path if any). This would also mean that `.git/HEAD` and `.git/refs` will be included in the docker image.
Upstream docker images now are additionally tagged by commit for anyone that wants to downgrade to a specific commit.