### PR TITLE
fix filenames with special characters like spaces + fix mime type uploads for bash uploader

### DIFF
--- a/src/components/pages/settings/parts/SettingsGenerators/GeneratorButton.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/GeneratorButton.tsx
@@ -45,7 +45,6 @@ export type GeneratorOptions = {
 };
 
 export const copier = (options: GeneratorOptions) => {
-  if (options.unix_useEcho) return 'echo';
   if (options.mac_enableCompatibility) return 'pbcopy';
   if (options.wl_enableCompatibility) return 'wl-copy';
   return 'xclip -selection clipboard';

--- a/src/components/pages/settings/parts/SettingsGenerators/generators/shell.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/generators/shell.tsx
@@ -61,20 +61,21 @@ export function shell(token: string, type: 'file' | 'url', options: GeneratorOpt
   }
 
   for (const [key, value] of Object.entries(toAddHeaders)) {
-    curl.push('-H', `${key}: ${value}`);
+    curl.push('-H', `"${key}: ${value}"`);
   }
 
   let script;
 
   if (type === 'file') {
     script = `#!/bin/bash
-${curl.join(' ')}${options.noJson ? '' : ' | jq -r .files[0].url'} | tr -d '\\n' | ${copier(options)}
+${curl.join(' ')}${options.noJson ? '' : ' | jq -r .files[0].url'}${
+    options.unix_useEcho ? '' : ` | ${copier(options)}`}
 `;
   } else {
     script = `#!/bin/bash
-${curl.join(' ')} -d "{\\"url\\": \\"$1\\"}"${
-      options.noJson ? '' : ' | jq -r .files[0].url'
-    } | tr -d '\\n' | ${copier(options)}
+${curl.join(' ')} -d "{\\"destination\\": \\"$1\\"}"${
+      options.noJson ? '' : ' | jq -r .url'
+    }${options.unix_useEcho ? '' : ` | ${copier(options)}`}
 `;
   }
 

--- a/src/components/pages/settings/parts/SettingsGenerators/generators/shell.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/generators/shell.tsx
@@ -10,7 +10,7 @@ export function shell(token: string, type: 'file' | 'url', options: GeneratorOpt
   ];
 
   if (type === 'file') {
-    curl.push('-F', 'file=@$1');
+    curl.push('-F', '"file=@$1;type=$(file --mime-type -b "$1")"');
     curl.push('-H', "'content-type: multipart/form-data'");
   } else {
     curl.push('-H', "'content-type: application/json'");

--- a/src/components/pages/settings/parts/SettingsGenerators/generators/shell.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/generators/shell.tsx
@@ -69,7 +69,8 @@ export function shell(token: string, type: 'file' | 'url', options: GeneratorOpt
   if (type === 'file') {
     script = `#!/bin/bash
 ${curl.join(' ')}${options.noJson ? '' : ' | jq -r .files[0].url'}${
-    options.unix_useEcho ? '' : ` | ${copier(options)}`}
+      options.unix_useEcho ? '' : ` | ${copier(options)}`
+    }
 `;
   } else {
     script = `#!/bin/bash

--- a/src/components/pages/settings/parts/SettingsGenerators/index.tsx
+++ b/src/components/pages/settings/parts/SettingsGenerators/index.tsx
@@ -79,6 +79,10 @@ export default function SettingsGenerators() {
                 <Code>curl</Code>
               </Anchor>
               ,{' '}
+              <Anchor component={Link} href='https://darwinsys.com/file/'>
+                <Code>file</Code>
+              </Anchor>
+              ,{' '}
               <Anchor component={Link} href='https://github.com/stedolan/jq'>
                 <Code>jq</Code>
               </Anchor>


### PR DESCRIPTION
Hey,

I especially noticed that if you upload a video (tried with webm/mp4) you end up with an application/octet-stream

This PR:
* encapsulates the flag option to pass filenames that have special characters like spaces (thanks to windows).
* adds a proper MIME type for uploads using `file` command in shell script that is pretty much installed in the vast majority of any UNIX host.