### PR TITLE
feat: add loginDuration option

### DIFF
--- a/prisma/migrations/20250430092654_login_duration_setting/migration.sql
+++ b/prisma/migrations/20250430092654_login_duration_setting/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Zipline" ADD COLUMN     "loginDuration" INTEGER NOT NULL DEFAULT 7;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,6 +129,8 @@ model Zipline {
   pwaDescription     String  @default("Zipline")
   pwaThemeColor      String  @default("#000000")
   pwaBackgroundColor String  @default("#000000")
+
+  loginDuration   Int @default(7)
 }
 
 model User {

--- a/src/components/pages/serverSettings/parts/ServerSettingsCore.tsx
+++ b/src/components/pages/serverSettings/parts/ServerSettingsCore.tsx
@@ -1,5 +1,14 @@
 import { Response } from '@/lib/api/response';
-import { Button, LoadingOverlay, Paper, SimpleGrid, Switch, TextInput, Title } from '@mantine/core';
+import {
+  Button,
+  NumberInput,
+  LoadingOverlay,
+  Paper,
+  SimpleGrid,
+  Switch,
+  TextInput,
+  Title,
+} from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconDeviceFloppy } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
@@ -16,11 +25,13 @@ export default function ServerSettingsCore({
     coreReturnHttpsUrls: boolean;
     coreDefaultDomain: string | null | undefined;
     coreTempDirectory: string;
+    loginDuration: number;
   }>({
     initialValues: {
       coreReturnHttpsUrls: false,
       coreDefaultDomain: '',
       coreTempDirectory: '/tmp/zipline',
+      loginDuration: 7,
     },
   });
 
@@ -39,6 +50,7 @@ export default function ServerSettingsCore({
       coreReturnHttpsUrls: data?.coreReturnHttpsUrls ?? false,
       coreDefaultDomain: data?.coreDefaultDomain ?? '',
       coreTempDirectory: data?.coreTempDirectory ?? '/tmp/zipline',
+      loginDuration: data?.loginDuration ?? 7,
     });
   }, [data]);
 
@@ -69,6 +81,14 @@ export default function ServerSettingsCore({
             description='The directory to store temporary files. If the path is invalid, certain functions may break. Requires a server restart.'
             placeholder='/tmp/zipline'
             {...form.getInputProps('coreTempDirectory')}
+          />
+
+          <NumberInput
+            label='Session duration'
+            description='Number of days that users stay logged in for'
+            placeholder='7'
+            min={1}
+            {...form.getInputProps('loginDuration')}
           />
         </SimpleGrid>
 

--- a/src/lib/config/read.ts
+++ b/src/lib/config/read.ts
@@ -282,6 +282,8 @@ export const DATABASE_TO_PROP = {
   pwaDescription: 'pwa.description',
   pwaThemeColor: 'pwa.themeColor',
   pwaBackgroundColor: 'pwa.backgroundColor',
+
+  loginDuration: 'login.loginDuration',
 };
 
 const logger = log('config').c('read');

--- a/src/lib/config/validate.ts
+++ b/src/lib/config/validate.ts
@@ -317,6 +317,9 @@ export const schema = z.object({
     themeColor: z.string().default('#000000'),
     backgroundColor: z.string().default('#000000'),
   }),
+  login: z.object({
+    loginDuration: z.number().default(7),
+  }),
 });
 
 export type Config = z.infer<typeof schema>;

--- a/src/server/routes/api/server/settings.ts
+++ b/src/server/routes/api/server/settings.ts
@@ -270,6 +270,7 @@ export default fastifyPlugin(
             pwaDescription: z.string(),
             pwaThemeColor: z.string().regex(/^#?([a-f0-9]{6}|[a-f0-9]{3})$/),
             pwaBackgroundColor: z.string().regex(/^#?([a-f0-9]{6}|[a-f0-9]{3})/),
+            loginDuration: z.number().refine((value) => value > 0, 'Value must be greater than 0'),
           })
           .partial()
           .refine(

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -5,20 +5,23 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { IncomingMessage, ServerResponse } from 'http';
 import { getIronSession, type SessionOptions } from 'iron-session';
 
-const cookieOptions: SessionOptions['cookieOptions'] = {
-  // week
-  maxAge: 60 * 60 * 24 * 7,
-  expires: new Date(Date.now() + 60 * 60 * 24 * 7 * 1000),
-  path: '/',
-  sameSite: 'lax',
-  httpOnly: false,
-  secure: false,
-};
-
 export type ZiplineSession = {
   id: string | null;
   sessionId: string | null;
 };
+
+export function computeCookieOptions(): SessionOptions['cookieOptions'] {
+  const loginDuration = config.login.loginDuration;
+
+  return {
+    maxAge: 60 * 60 * 24 * loginDuration,
+    expires: new Date(Date.now() + 60 * 60 * 24 * loginDuration * 1000),
+    path: '/',
+    sameSite: 'lax',
+    httpOnly: false,
+    secure: false,
+  };
+}
 
 export async function getSession(
   req: FastifyRequest | IncomingMessage,
@@ -31,7 +34,7 @@ export async function getSession(
       {
         password: config.core.secret,
         cookieName: 'zipline_session',
-        cookieOptions,
+        cookieOptions: computeCookieOptions(),
       },
     );
 
@@ -44,7 +47,7 @@ export async function getSession(
     {
       password: config.core.secret,
       cookieName: 'zipline_session',
-      cookieOptions,
+      cookieOptions: computeCookieOptions(),
     },
   );
 


### PR DESCRIPTION
Currently, zipline is hardcoded to logout all users after 7 days. This is a pretty annoying thing, as opposed to most other services where user is usually logged in indefinitely or at least for a much longer time.

PR fixes this by adding an option that allows admin to change this 7 day time to any other number.