### PR TITLE
Add the `service_healthy` requirement to Zipline's `depends_on:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ services:
     environment:
       - DATABASE_URL=postgres://${POSTGRESQL_USER:-zipline}:${POSTGRESQL_PASSWORD}@postgresql:5432/${POSTGRESQL_DB:-zipline}
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
     volumes:
       - './uploads:/zipline/uploads'
       - './public:/zipline/public'

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ services:
       - './uploads:/zipline/uploads'
       - './public:/zipline/public'
       - './themes:/zipline/themes'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3000/api/healthcheck']
+      interval: 15s
+      timeout: 2s
+      retries: 2
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,11 @@ services:
       - './uploads:/zipline/uploads'
       - './public:/zipline/public'
       - './themes:/zipline/themes'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3000/api/healthcheck']
+      interval: 15s
+      timeout: 2s
+      retries: 2
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
     environment:
       - DATABASE_URL=postgres://${POSTGRESQL_USER:-zipline}:${POSTGRESQL_PASSWORD}@postgresql:5432/${POSTGRESQL_DB:-zipline}
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
     volumes:
       - './uploads:/zipline/uploads'
       - './public:/zipline/public'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - './public:/zipline/public'
       - './themes:/zipline/themes'
     healthcheck:
-      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3000/api/healthcheck']
+      test: ['CMD', 'wget', '-q', '--spider', 'http://0.0.0.0:3000/api/healthcheck']
       interval: 15s
       timeout: 2s
       retries: 2


### PR DESCRIPTION
Since you use healthcheck anyway, you get to verify that postgres is healthy before starting Zipline