### PR TITLE
Fix environment variable mismatch when comparing to docs & change data type of `RATELIMIT_WINDOW`

### DIFF
--- a/src/lib/config/read/env.ts
+++ b/src/lib/config/read/env.ts
@@ -119,7 +119,7 @@ export const ENVS = [
 
   env('ratelimit.enabled', 'RATELIMIT_ENABLED', 'boolean', true),
   env('ratelimit.max', 'RATELIMIT_MAX', 'number', true),
-  env('ratelimit.window', 'RATELIMIT_WINDOW', 'string', true),
+  env('ratelimit.window', 'RATELIMIT_WINDOW', 'number', true),
   env('ratelimit.adminBypass', 'RATELIMIT_ADMIN_BYPASS', 'boolean', true),
   env('ratelimit.allowList', 'RATELIMIT_ALLOW_LIST', 'string[]', true),
 

--- a/src/lib/config/read/env.ts
+++ b/src/lib/config/read/env.ts
@@ -56,7 +56,7 @@ export const ENVS = [
   env('files.defaultDateFormat', 'FILES_DEFAULT_DATE_FORMAT', 'string', true),
   env('files.removeGpsMetadata', 'FILES_REMOVE_GPS_METADATA', 'boolean', true),
   env('files.randomWordsNumAdjectives', 'FILES_RANDOM_WORDS_NUM_ADJECTIVES', 'number', true),
-  env('files.randomWordsSeparator', 'FILES_RANDOM_WORDS_Separator', 'string', true),
+  env('files.randomWordsSeparator', 'FILES_RANDOM_WORDS_SEPARATOR', 'string', true),
 
   env('urls.route', 'URLS_ROUTE', 'string', true),
   env('urls.length', 'URLS_LENGTH', 'number', true),


### PR DESCRIPTION
I was transitioning over to environment variables for my Zipline instance, but faced two issues:

1. FILES_RANDOM_WORDS_SEPARATOR did not seem to affect my Zipline settings. Found out this was because the "Separator" in the code was not capitalised. I was following the docs, so I did not know this. In the docs the entire variable is capitalised.

2. When setting RATELIMIT_WINDOW to 10, I got an error:
    > zipline  | [2025-08-09T03:57:34 ERROR  config::validate] RATELIMIT_WINDOW: Expected number, received string

    What's weird is its put as string in the docs as well, but I'm assuming it's meant to be a number either way since it is mentioned in the description this is the amount of seconds.