### PR TITLE
Increase TLD length to 30 in Domain Verification Check

### DIFF
--- a/src/components/pages/serverSettings/parts/Domains.tsx
+++ b/src/components/pages/serverSettings/parts/Domains.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { settingsOnSubmit } from '../settingsOnSubmit';
 
 const DOMAIN_REGEX =
-  /^[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.([a-zA-Z]{1,6}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,3})$/gim;
+  /^[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.([a-zA-Z]{1,6}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,30})$/gim;
 
 export default function Domains({
   swr: { data, isLoading },

--- a/src/server/routes/api/server/settings/index.ts
+++ b/src/server/routes/api/server/settings/index.ts
@@ -321,7 +321,7 @@ export default fastifyPlugin(
                 z
                   .string()
                   .regex(
-                    /^[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.([a-zA-Z]{1,6}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,3})$/gi,
+                    /^[a-zA-Z0-9][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9]{0,1}\.([a-zA-Z]{1,6}|[a-zA-Z0-9-]{1,30}\.[a-zA-Z]{2,30})$/gi,
                     'Invalid Domain',
                   ),
               ),


### PR DESCRIPTION
In the latest version of Zipline (4.3.1), I discovered that the ability to add domains is validated by a Regex query that is too strict for certain TLDs. This PR raises the limit to 30 characters to match the Second Level Domain's current 30 Character maximum, which covers all currently active TLDs per the ICANN List<sup>1</sup> referenced below.

This issue can be reproduced by adding a domain such as `zip.konpeki.solutions`, which uses the `.solutions` TLD officially recognized by ICANN. The image below shows the behavior before this change.

<img width="274" height="237" alt="image" src="https://github.com/user-attachments/assets/1e109ea7-fcce-4348-86af-948a8fc619a5" />

<sup>1</sup> ICANN List of Current TLDs: https://data.iana.org/TLD/tlds-alpha-by-domain.txt
Current Longest TLD is 24 characters, this can be checked by running the command in [this StackOverflow comment](https://stackoverflow.com/a/22038535).
