### PR TITLE
Feature: nested folders

### DIFF
--- a/prisma/migrations/20260114182751_add_nested_folders/migration.sql
+++ b/prisma/migrations/20260114182751_add_nested_folders/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "public"."Folder" ADD COLUMN     "parentId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "public"."Folder" ADD CONSTRAINT "Folder_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "public"."Folder"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -306,6 +306,10 @@ model Folder {
 
   files File[]
 
+  parentId String?
+  parent   Folder?  @relation("FolderToFolder", fields: [parentId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  children Folder[] @relation("FolderToFolder")
+
   User   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   userId String
 }

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,14 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="manifest" href="manifest.json">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="manifest.json" />
 
-		<title>Zipline</title>
-	</head>
-	<body>
-		<div id="root"></div>
-		<script type="module" src="/main.tsx"></script>
-	</body>
+    <title>Zipline</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
 </html>

--- a/src/client/pages/folder/[id]/index.tsx
+++ b/src/client/pages/folder/[id]/index.tsx
@@ -1,5 +1,4 @@
 import { type Response } from '@/lib/api/response';
-import { useTitle } from '@/lib/hooks/useTitle';
 import { Folder } from '@/lib/db/models/folder';
 import {
   ActionIcon,
@@ -61,18 +60,15 @@ export function Component() {
   const { folder } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
 
-  // Build breadcrumb from parent chain
   const buildBreadcrumbs = () => {
     const items: { id: string | null; name: string; public: boolean }[] = [];
 
-    // Walk up parent chain (only public parents)
     let current = folder.parent as Partial<Folder> | undefined;
     while (current && current.public) {
       items.unshift({ id: current.id!, name: current.name!, public: true });
       current = current.parent as Partial<Folder> | undefined;
     }
 
-    // Add current folder
     items.push({ id: folder.id!, name: folder.name!, public: true });
 
     return items;

--- a/src/client/pages/folder/[id]/index.tsx
+++ b/src/client/pages/folder/[id]/index.tsx
@@ -42,7 +42,9 @@ function PublicFolderCard({ folder }: { folder: Partial<Folder> }) {
         </Card.Section>
         <Card.Section inheritPadding py='xs'>
           <Stack gap={2}>
-            <Text size='xs' c='dimmed'>{folder._count?.files ?? 0} files</Text>
+            <Text size='xs' c='dimmed'>
+              {folder._count?.files ?? 0} files
+            </Text>
             {(folder._count?.children ?? 0) > 0 && (
               <Text size='xs' c='dimmed'>
                 {folder._count?.children} subfolders

--- a/src/client/pages/folder/[id]/index.tsx
+++ b/src/client/pages/folder/[id]/index.tsx
@@ -1,9 +1,22 @@
 import { type Response } from '@/lib/api/response';
 import { useTitle } from '@/lib/hooks/useTitle';
-import { ActionIcon, Container, Group, SimpleGrid, Skeleton, Title } from '@mantine/core';
-import { IconUpload } from '@tabler/icons-react';
+import { Folder } from '@/lib/db/models/folder';
+import {
+  ActionIcon,
+  Anchor,
+  Breadcrumbs,
+  Card,
+  Container,
+  Group,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconFolder, IconHome, IconUpload } from '@tabler/icons-react';
 import { lazy, Suspense } from 'react';
-import { Link, Params, useLoaderData } from 'react-router-dom';
+import { Link, Params, useLoaderData, useNavigate } from 'react-router-dom';
 
 const DashboardFile = lazy(() => import('@/components/file/DashboardFile'));
 
@@ -17,14 +30,75 @@ export async function loader({ params }: { params: Params<string> }) {
   };
 }
 
+function PublicFolderCard({ folder }: { folder: Partial<Folder> }) {
+  return (
+    <Link to={`/folder/${folder.id}`} style={{ textDecoration: 'none' }}>
+      <Card withBorder shadow='sm' radius='sm' style={{ cursor: 'pointer' }}>
+        <Card.Section withBorder inheritPadding py='xs'>
+          <Group gap='xs'>
+            <IconFolder size='1.2rem' />
+            <Text fw={500}>{folder.name}</Text>
+          </Group>
+        </Card.Section>
+        <Card.Section inheritPadding py='xs'>
+          <Stack gap={2}>
+            <Text size='xs' c='dimmed'>
+              {(folder._count?.files ?? 0)} files
+            </Text>
+            {(folder._count?.children ?? 0) > 0 && (
+              <Text size='xs' c='dimmed'>
+                {folder._count?.children} subfolders
+              </Text>
+            )}
+          </Stack>
+        </Card.Section>
+      </Card>
+    </Link>
+  );
+}
+
 export function Component() {
   const { folder } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
 
-  useTitle(folder.name ?? '');
+  // Build breadcrumb from parent chain
+  const buildBreadcrumbs = () => {
+    const items: { id: string | null; name: string; public: boolean }[] = [];
+
+    // Walk up parent chain (only public parents)
+    let current = folder.parent as Partial<Folder> | undefined;
+    while (current && current.public) {
+      items.unshift({ id: current.id!, name: current.name!, public: true });
+      current = current.parent as Partial<Folder> | undefined;
+    }
+
+    // Add current folder
+    items.push({ id: folder.id!, name: folder.name!, public: true });
+
+    return items;
+  };
+
+  const breadcrumbs = buildBreadcrumbs();
+  const children = (folder.children ?? []) as Partial<Folder>[];
 
   return (
     <>
       <Container my='lg'>
+        {breadcrumbs.length > 1 && (
+          <Breadcrumbs mb='md'>
+            {breadcrumbs.map((item, index) => (
+              <Anchor
+                key={item.id}
+                onClick={() => navigate(`/folder/${item.id}`)}
+                style={{ cursor: 'pointer' }}
+                fw={index === breadcrumbs.length - 1 ? 600 : 400}
+              >
+                {item.name}
+              </Anchor>
+            ))}
+          </Breadcrumbs>
+        )}
+
         <Group>
           <Title order={1}>{folder.name}</Title>
 
@@ -37,21 +111,54 @@ export function Component() {
           )}
         </Group>
 
-        <SimpleGrid
-          my='sm'
-          cols={{
-            base: 1,
-            lg: 3,
-            md: 2,
-          }}
-          spacing='md'
-        >
-          {folder.files?.map((file: any) => (
-            <Suspense fallback={<Skeleton height={350} animate />} key={file.id}>
-              <DashboardFile file={file} reduce />
-            </Suspense>
-          ))}
-        </SimpleGrid>
+        {children.length > 0 && (
+          <>
+            <Title order={3} mt='md' mb='sm'>
+              Subfolders
+            </Title>
+            <SimpleGrid
+              cols={{
+                base: 1,
+                lg: 4,
+                md: 3,
+                sm: 2,
+              }}
+              spacing='md'
+            >
+              {children.map((child) => (
+                <PublicFolderCard key={child.id} folder={child} />
+              ))}
+            </SimpleGrid>
+          </>
+        )}
+
+        {(folder.files?.length ?? 0) > 0 && (
+          <>
+            <Title order={3} mt='md' mb='sm'>
+              Files
+            </Title>
+            <SimpleGrid
+              cols={{
+                base: 1,
+                lg: 3,
+                md: 2,
+              }}
+              spacing='md'
+            >
+              {folder.files?.map((file: any) => (
+                <Suspense fallback={<Skeleton height={350} animate />} key={file.id}>
+                  <DashboardFile file={file} reduce />
+                </Suspense>
+              ))}
+            </SimpleGrid>
+          </>
+        )}
+
+        {children.length === 0 && (folder.files?.length ?? 0) === 0 && (
+          <Text c='dimmed' mt='md'>
+            This folder is empty.
+          </Text>
+        )}
       </Container>
     </>
   );

--- a/src/client/pages/folder/[id]/index.tsx
+++ b/src/client/pages/folder/[id]/index.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { IconFolder, IconHome, IconUpload } from '@tabler/icons-react';
+import { IconFolder, IconUpload } from '@tabler/icons-react';
 import { lazy, Suspense } from 'react';
 import { Link, Params, useLoaderData, useNavigate } from 'react-router-dom';
 
@@ -42,9 +42,7 @@ function PublicFolderCard({ folder }: { folder: Partial<Folder> }) {
         </Card.Section>
         <Card.Section inheritPadding py='xs'>
           <Stack gap={2}>
-            <Text size='xs' c='dimmed'>
-              {(folder._count?.files ?? 0)} files
-            </Text>
+            <Text size='xs' c='dimmed'>{folder._count?.files ?? 0} files</Text>
             {(folder._count?.children ?? 0) > 0 && (
               <Text size='xs' c='dimmed'>
                 {folder._count?.children} subfolders

--- a/src/client/routes.tsx
+++ b/src/client/routes.tsx
@@ -59,7 +59,7 @@ export const router = createBrowserRouter([
                   { path: 'metrics', lazy: () => import('./pages/dashboard/metrics') },
                   { path: 'settings', lazy: () => import('./pages/dashboard/settings') },
                   { path: 'files', lazy: () => import('./pages/dashboard/files') },
-                  { path: 'folders', lazy: () => import('./pages/dashboard/folders') },
+                  { path: 'folders/*', lazy: () => import('./pages/dashboard/folders') },
                   { path: 'urls', lazy: () => import('./pages/dashboard/urls') },
                   {
                     path: 'upload',

--- a/src/components/file/DashboardFile/FileModal.tsx
+++ b/src/components/file/DashboardFile/FileModal.tsx
@@ -50,6 +50,18 @@ import {
 import { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 
+function getFolderDepth(folder: Folder, foldersMap: Map<string, Folder>): number {
+  let depth = 0;
+  let current: Folder | undefined = folder.parentId ? foldersMap.get(folder.parentId) : undefined;
+
+  while (current) {
+    depth++;
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return depth;
+}
+
 function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
   const parts: string[] = [];
   let current: Folder | undefined = folder;
@@ -129,7 +141,7 @@ export default function FileModal({
         id: f.id,
         name: f.name,
         path: buildFolderPath(f, foldersMap),
-        depth: buildFolderPath(f, foldersMap).split(' / ').length - 1,
+        depth: getFolderDepth(f, foldersMap),
       }))
       .sort((a, b) => a.path.localeCompare(b.path));
   }, [folders]);

--- a/src/components/file/DashboardFile/FileModal.tsx
+++ b/src/components/file/DashboardFile/FileModal.tsx
@@ -1,10 +1,12 @@
+import FolderComboboxOptions from '@/components/folders/FolderComboboxOptions';
 import TagPill from '@/components/pages/files/tags/TagPill';
 import { Response } from '@/lib/api/response';
 import { bytes } from '@/lib/bytes';
 import { File } from '@/lib/db/models/file';
-import { Folder } from '@/lib/db/models/folder';
 import { Tag } from '@/lib/db/models/tag';
 import { fetchApi } from '@/lib/fetchApi';
+import { buildFolderHierarchy } from '@/lib/folderHierarchy';
+import { useFolders } from '@/lib/hooks/useFolders';
 import { useSettingsStore } from '@/lib/store/settings';
 import {
   ActionIcon,
@@ -103,52 +105,11 @@ export default function FileModal({
 
   const [editFileOpen, setEditFileOpen] = useState(false);
 
-  const { data: folders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
-    '/api/user/folders?noincl=true' + (user ? `&user=${user}` : ''),
-  );
+  const { data: folders } = useFolders(user);
 
-  // Build folder options with hierarchy using depth-first traversal
   const folderOptions = useMemo(() => {
     if (!folders) return [];
-
-    // Group children by parent
-    const childrenMap = new Map<string | null, Folder[]>();
-    for (const folder of folders) {
-      const parentId = folder.parentId ?? null;
-      const siblings = childrenMap.get(parentId) || [];
-      siblings.push(folder);
-      childrenMap.set(parentId, siblings);
-    }
-
-    // Sort children alphabetically within each level
-    for (const children of childrenMap.values()) {
-      children.sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    // Depth-first traversal to build ordered list
-    const result: Array<{ id: string; name: string; path: string; depth: number }> = [];
-
-    const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
-      const currentPath = [...pathParts, folder.name];
-      result.push({
-        id: folder.id,
-        name: folder.name,
-        path: currentPath.join(' / '),
-        depth,
-      });
-
-      const children = childrenMap.get(folder.id) || [];
-      for (const child of children) {
-        traverse(child, depth + 1, currentPath);
-      }
-    };
-
-    const rootFolders = childrenMap.get(null) || [];
-    for (const root of rootFolders) {
-      traverse(root, 0, []);
-    }
-
-    return result;
+    return buildFolderHierarchy(folders);
   }, [folders]);
 
   const folderCombobox = useCombobox();
@@ -370,11 +331,17 @@ export default function FileModal({
                             folderCombobox.updateSelectedOptionIndex();
                             setSearch(event.currentTarget.value);
                           }}
-                          onClick={() => folderCombobox.openDropdown()}
-                          onFocus={() => folderCombobox.openDropdown()}
+                          onClick={() => {
+                            folderCombobox.openDropdown();
+                            setSearch('');
+                          }}
+                          onFocus={() => {
+                            folderCombobox.openDropdown();
+                            setSearch('');
+                          }}
                           onBlur={() => {
                             folderCombobox.closeDropdown();
-                            setSearch(search || '');
+                            setSearch('');
                           }}
                           placeholder='Add to folder...'
                           rightSectionPointerEvents='none'
@@ -382,25 +349,18 @@ export default function FileModal({
                       </Combobox.Target>
 
                       <Combobox.Dropdown>
-                        <Combobox.Options>
-                          {folderOptions
-                            .filter((f) => f.path.toLowerCase().includes(search.toLowerCase().trim()))
-                            .map((f) => (
-                              <Combobox.Option value={f.id} key={f.id}>
-                                <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
-                                  {f.depth > 0 ? '└ ' : ''}
-                                  {f.name}
-                                </Text>
-                              </Combobox.Option>
-                            ))}
-
-                          {!folders?.some((f: { name: string }) => f.name === search) &&
-                            search.trim().length > 0 && (
+                        <FolderComboboxOptions
+                          folderOptions={folderOptions}
+                          searchValue={search}
+                          additionalOptions={
+                            !folders?.some((f: { name: string }) => f.name === search) &&
+                            search.trim().length > 0 ? (
                               <Combobox.Option value='$create'>
                                 + Create folder &quot;{search}&quot;
                               </Combobox.Option>
-                            )}
-                        </Combobox.Options>
+                            ) : null
+                          }
+                        />
                       </Combobox.Dropdown>
                     </Combobox>
                   )}

--- a/src/components/file/DashboardFile/FileModal.tsx
+++ b/src/components/file/DashboardFile/FileModal.tsx
@@ -50,29 +50,6 @@ import {
 import { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 
-function getFolderDepth(folder: Folder, foldersMap: Map<string, Folder>): number {
-  let depth = 0;
-  let current: Folder | undefined = folder.parentId ? foldersMap.get(folder.parentId) : undefined;
-
-  while (current) {
-    depth++;
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return depth;
-}
-
-function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
-  const parts: string[] = [];
-  let current: Folder | undefined = folder;
-
-  while (current) {
-    parts.unshift(current.name);
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return parts.join(' / ');
-}
 import DashboardFileType from '../DashboardFileType';
 import {
   addToFolder,
@@ -130,20 +107,48 @@ export default function FileModal({
     '/api/user/folders?noincl=true' + (user ? `&user=${user}` : ''),
   );
 
-  // Build folder options with full path for hierarchy display
+  // Build folder options with hierarchy using depth-first traversal
   const folderOptions = useMemo(() => {
     if (!folders) return [];
 
-    const foldersMap = new Map(folders.map((f: Folder) => [f.id, f]));
+    // Group children by parent
+    const childrenMap = new Map<string | null, Folder[]>();
+    for (const folder of folders) {
+      const parentId = folder.parentId ?? null;
+      const siblings = childrenMap.get(parentId) || [];
+      siblings.push(folder);
+      childrenMap.set(parentId, siblings);
+    }
 
-    return folders
-      .map((f: Folder) => ({
-        id: f.id,
-        name: f.name,
-        path: buildFolderPath(f, foldersMap),
-        depth: getFolderDepth(f, foldersMap),
-      }))
-      .sort((a, b) => a.path.localeCompare(b.path));
+    // Sort children alphabetically within each level
+    for (const children of childrenMap.values()) {
+      children.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Depth-first traversal to build ordered list
+    const result: Array<{ id: string; name: string; path: string; depth: number }> = [];
+
+    const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
+      const currentPath = [...pathParts, folder.name];
+      result.push({
+        id: folder.id,
+        name: folder.name,
+        path: currentPath.join(' / '),
+        depth,
+      });
+
+      const children = childrenMap.get(folder.id) || [];
+      for (const child of children) {
+        traverse(child, depth + 1, currentPath);
+      }
+    };
+
+    const rootFolders = childrenMap.get(null) || [];
+    for (const root of rootFolders) {
+      traverse(root, 0, []);
+    }
+
+    return result;
   }, [folders]);
 
   const folderCombobox = useCombobox();

--- a/src/components/file/DashboardFile/FileModal.tsx
+++ b/src/components/file/DashboardFile/FileModal.tsx
@@ -47,8 +47,20 @@ import {
   IconTrashFilled,
   IconUpload,
 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
+
+function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
+  const parts: string[] = [];
+  let current: Folder | undefined = folder;
+
+  while (current) {
+    parts.unshift(current.name);
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return parts.join(' / ');
+}
 import DashboardFileType from '../DashboardFileType';
 import {
   addToFolder,
@@ -105,6 +117,22 @@ export default function FileModal({
   const { data: folders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
     '/api/user/folders?noincl=true' + (user ? `&user=${user}` : ''),
   );
+
+  // Build folder options with full path for hierarchy display
+  const folderOptions = useMemo(() => {
+    if (!folders) return [];
+
+    const foldersMap = new Map(folders.map((f: Folder) => [f.id, f]));
+
+    return folders
+      .map((f: Folder) => ({
+        id: f.id,
+        name: f.name,
+        path: buildFolderPath(f, foldersMap),
+        depth: buildFolderPath(f, foldersMap).split(' / ').length - 1,
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }, [folders]);
 
   const folderCombobox = useCombobox();
   const [search, setSearch] = useState('');
@@ -338,13 +366,14 @@ export default function FileModal({
 
                       <Combobox.Dropdown>
                         <Combobox.Options>
-                          {folders
-                            ?.filter((f: { name: string }) =>
-                              f.name.toLowerCase().includes(search.toLowerCase().trim()),
-                            )
-                            .map((f: { name: string; id: string }) => (
+                          {folderOptions
+                            .filter((f) => f.path.toLowerCase().includes(search.toLowerCase().trim()))
+                            .map((f) => (
                               <Combobox.Option value={f.id} key={f.id}>
-                                {f.name}
+                                <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
+                                  {f.depth > 0 ? '└ ' : ''}
+                                  {f.name}
+                                </Text>
                               </Combobox.Option>
                             ))}
 

--- a/src/components/folders/FolderComboboxOptions.tsx
+++ b/src/components/folders/FolderComboboxOptions.tsx
@@ -1,0 +1,34 @@
+import { FolderHierarchyItem } from '@/lib/folderHierarchy';
+import { Combobox, Text } from '@mantine/core';
+
+interface FolderComboboxOptionsProps {
+  folderOptions: FolderHierarchyItem[];
+  searchValue: string;
+  additionalOptions?: React.ReactNode;
+}
+
+/**
+ * Renders folder options in a Combobox dropdown with proper indentation and tree symbols.
+ * Filters folders by search value (case-insensitive path match).
+ */
+export default function FolderComboboxOptions({
+  folderOptions,
+  searchValue,
+  additionalOptions,
+}: FolderComboboxOptionsProps) {
+  return (
+    <Combobox.Options>
+      {additionalOptions}
+      {folderOptions
+        .filter((f) => f.path.toLowerCase().includes(searchValue.toLowerCase().trim()))
+        .map((f) => (
+          <Combobox.Option value={f.id} key={f.id}>
+            <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
+              {f.depth > 0 ? '└ ' : ''}
+              {f.name}
+            </Text>
+          </Combobox.Option>
+        ))}
+    </Combobox.Options>
+  );
+}

--- a/src/components/pages/files/views/FileTable.tsx
+++ b/src/components/pages/files/views/FileTable.tsx
@@ -38,9 +38,21 @@ import {
   IconTrashFilled,
 } from '@tabler/icons-react';
 import { DataTable } from 'mantine-datatable';
-import { lazy, useEffect, useReducer, useState } from 'react';
+import { lazy, useEffect, useMemo, useReducer, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
+
+function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
+  const parts: string[] = [];
+  let current: Folder | undefined = folder;
+
+  while (current) {
+    parts.unshift(current.name);
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return parts.join(' / ');
+}
 import TableEditModal, { NAMES } from '../TableEditModal';
 import { bulkDelete, bulkFavorite } from '../bulk';
 import TagPill from '../tags/TagPill';
@@ -196,6 +208,22 @@ export default function FileTable({
   const { data: folders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
     '/api/user/folders?noincl=true',
   );
+
+  // Build folder options with full path for hierarchy display
+  const folderOptions = useMemo(() => {
+    if (!folders) return [];
+
+    const foldersMap = new Map(folders.map((f) => [f.id, f]));
+
+    return folders
+      .map((f) => ({
+        id: f.id,
+        name: f.name,
+        path: buildFolderPath(f, foldersMap),
+        depth: buildFolderPath(f, foldersMap).split(' / ').length - 1,
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }, [folders]);
 
   const [page, setPage] = useQueryState('page', 1);
   const [perpage, setPerpage] = useState(20);
@@ -447,11 +475,14 @@ export default function FileTable({
 
                     <Combobox.Dropdown>
                       <Combobox.Options>
-                        {folders
-                          ?.filter((f) => f.name.toLowerCase().includes(folderSearch.toLowerCase().trim()))
+                        {folderOptions
+                          .filter((f) => f.path.toLowerCase().includes(folderSearch.toLowerCase().trim()))
                           .map((f) => (
                             <Combobox.Option value={f.id} key={f.id}>
-                              {f.name}
+                              <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
+                                {f.depth > 0 ? '└ ' : ''}
+                                {f.name}
+                              </Text>
                             </Combobox.Option>
                           ))}
                       </Combobox.Options>

--- a/src/components/pages/files/views/FileTable.tsx
+++ b/src/components/pages/files/views/FileTable.tsx
@@ -42,6 +42,18 @@ import { lazy, useEffect, useMemo, useReducer, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
+function getFolderDepth(folder: Folder, foldersMap: Map<string, Folder>): number {
+  let depth = 0;
+  let current: Folder | undefined = folder.parentId ? foldersMap.get(folder.parentId) : undefined;
+
+  while (current) {
+    depth++;
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return depth;
+}
+
 function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
   const parts: string[] = [];
   let current: Folder | undefined = folder;
@@ -220,7 +232,7 @@ export default function FileTable({
         id: f.id,
         name: f.name,
         path: buildFolderPath(f, foldersMap),
-        depth: buildFolderPath(f, foldersMap).split(' / ').length - 1,
+        depth: getFolderDepth(f, foldersMap),
       }))
       .sort((a, b) => a.path.localeCompare(b.path));
   }, [folders]);

--- a/src/components/pages/files/views/FileTable.tsx
+++ b/src/components/pages/files/views/FileTable.tsx
@@ -1,10 +1,12 @@
+import FolderComboboxOptions from '@/components/folders/FolderComboboxOptions';
 import RelativeDate from '@/components/RelativeDate';
 import { addMultipleToFolder, copyFile, deleteFile, downloadFile } from '@/components/file/actions';
 import { Response } from '@/lib/api/response';
 import { bytes } from '@/lib/bytes';
 import { type File } from '@/lib/db/models/file';
-import { Folder } from '@/lib/db/models/folder';
 import { Tag } from '@/lib/db/models/tag';
+import { buildFolderHierarchy } from '@/lib/folderHierarchy';
+import { useFolders } from '@/lib/hooks/useFolders';
 import { useQueryState } from '@/lib/hooks/useQueryState';
 import { useFileTableSettingsStore } from '@/lib/store/fileTableSettings';
 import { useSettingsStore } from '@/lib/store/settings';
@@ -194,52 +196,11 @@ export default function FileTable({
 
   const fields = useFileTableSettingsStore((state) => state.fields);
 
-  const { data: folders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
-    '/api/user/folders?noincl=true',
-  );
+  const { data: folders } = useFolders();
 
-  // Build folder options with hierarchy using depth-first traversal
   const folderOptions = useMemo(() => {
     if (!folders) return [];
-
-    // Group children by parent
-    const childrenMap = new Map<string | null, Folder[]>();
-    for (const folder of folders) {
-      const parentId = folder.parentId ?? null;
-      const siblings = childrenMap.get(parentId) || [];
-      siblings.push(folder);
-      childrenMap.set(parentId, siblings);
-    }
-
-    // Sort children alphabetically within each level
-    for (const children of childrenMap.values()) {
-      children.sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    // Depth-first traversal to build ordered list
-    const result: Array<{ id: string; name: string; path: string; depth: number }> = [];
-
-    const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
-      const currentPath = [...pathParts, folder.name];
-      result.push({
-        id: folder.id,
-        name: folder.name,
-        path: currentPath.join(' / '),
-        depth,
-      });
-
-      const children = childrenMap.get(folder.id) || [];
-      for (const child of children) {
-        traverse(child, depth + 1, currentPath);
-      }
-    };
-
-    const rootFolders = childrenMap.get(null) || [];
-    for (const root of rootFolders) {
-      traverse(root, 0, []);
-    }
-
-    return result;
+    return buildFolderHierarchy(folders);
   }, [folders]);
 
   const [page, setPage] = useQueryState('page', 1);
@@ -479,11 +440,17 @@ export default function FileTable({
                           combobox.updateSelectedOptionIndex();
                           setFolderSearch(event.currentTarget.value);
                         }}
-                        onClick={() => combobox.openDropdown()}
-                        onFocus={() => combobox.openDropdown()}
+                        onClick={() => {
+                          combobox.openDropdown();
+                          setFolderSearch('');
+                        }}
+                        onFocus={() => {
+                          combobox.openDropdown();
+                          setFolderSearch('');
+                        }}
                         onBlur={() => {
                           combobox.closeDropdown();
-                          setFolderSearch(folderSearch || '');
+                          setFolderSearch('');
                         }}
                         placeholder='Add to folder...'
                         rightSectionPointerEvents='none'
@@ -491,18 +458,7 @@ export default function FileTable({
                     </Combobox.Target>
 
                     <Combobox.Dropdown>
-                      <Combobox.Options>
-                        {folderOptions
-                          .filter((f) => f.path.toLowerCase().includes(folderSearch.toLowerCase().trim()))
-                          .map((f) => (
-                            <Combobox.Option value={f.id} key={f.id}>
-                              <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
-                                {f.depth > 0 ? '└ ' : ''}
-                                {f.name}
-                              </Text>
-                            </Combobox.Option>
-                          ))}
-                      </Combobox.Options>
+                      <FolderComboboxOptions folderOptions={folderOptions} searchValue={folderSearch} />
                     </Combobox.Dropdown>
                   </Combobox>
                 )}

--- a/src/components/pages/files/views/FileTable.tsx
+++ b/src/components/pages/files/views/FileTable.tsx
@@ -42,29 +42,6 @@ import { lazy, useEffect, useMemo, useReducer, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 
-function getFolderDepth(folder: Folder, foldersMap: Map<string, Folder>): number {
-  let depth = 0;
-  let current: Folder | undefined = folder.parentId ? foldersMap.get(folder.parentId) : undefined;
-
-  while (current) {
-    depth++;
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return depth;
-}
-
-function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
-  const parts: string[] = [];
-  let current: Folder | undefined = folder;
-
-  while (current) {
-    parts.unshift(current.name);
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return parts.join(' / ');
-}
 import TableEditModal, { NAMES } from '../TableEditModal';
 import { bulkDelete, bulkFavorite } from '../bulk';
 import TagPill from '../tags/TagPill';
@@ -221,20 +198,48 @@ export default function FileTable({
     '/api/user/folders?noincl=true',
   );
 
-  // Build folder options with full path for hierarchy display
+  // Build folder options with hierarchy using depth-first traversal
   const folderOptions = useMemo(() => {
     if (!folders) return [];
 
-    const foldersMap = new Map(folders.map((f) => [f.id, f]));
+    // Group children by parent
+    const childrenMap = new Map<string | null, Folder[]>();
+    for (const folder of folders) {
+      const parentId = folder.parentId ?? null;
+      const siblings = childrenMap.get(parentId) || [];
+      siblings.push(folder);
+      childrenMap.set(parentId, siblings);
+    }
 
-    return folders
-      .map((f) => ({
-        id: f.id,
-        name: f.name,
-        path: buildFolderPath(f, foldersMap),
-        depth: getFolderDepth(f, foldersMap),
-      }))
-      .sort((a, b) => a.path.localeCompare(b.path));
+    // Sort children alphabetically within each level
+    for (const children of childrenMap.values()) {
+      children.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Depth-first traversal to build ordered list
+    const result: Array<{ id: string; name: string; path: string; depth: number }> = [];
+
+    const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
+      const currentPath = [...pathParts, folder.name];
+      result.push({
+        id: folder.id,
+        name: folder.name,
+        path: currentPath.join(' / '),
+        depth,
+      });
+
+      const children = childrenMap.get(folder.id) || [];
+      for (const child of children) {
+        traverse(child, depth + 1, currentPath);
+      }
+    };
+
+    const rootFolders = childrenMap.get(null) || [];
+    for (const root of rootFolders) {
+      traverse(root, 0, []);
+    }
+
+    return result;
   }, [folders]);
 
   const [page, setPage] = useQueryState('page', 1);

--- a/src/components/pages/folders/DeleteFolderModal.tsx
+++ b/src/components/pages/folders/DeleteFolderModal.tsx
@@ -1,0 +1,189 @@
+import FolderComboboxOptions from '@/components/folders/FolderComboboxOptions';
+import { Response } from '@/lib/api/response';
+import { Folder } from '@/lib/db/models/folder';
+import { fetchApi } from '@/lib/fetchApi';
+import { buildFolderHierarchy } from '@/lib/folderHierarchy';
+import { useFolders } from '@/lib/hooks/useFolders';
+import { Button, Combobox, InputBase, Modal, Radio, Stack, Text, useCombobox } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconTrashFilled } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { mutate } from 'swr';
+
+interface DeleteFolderModalProps {
+  folder: Folder | null;
+  opened: boolean;
+  onClose: () => void;
+}
+
+type ChildrenAction = 'moveToRoot' | 'moveToFolder' | 'cascade';
+
+export default function DeleteFolderModal({ folder, opened, onClose }: DeleteFolderModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [childrenAction, setChildrenAction] = useState<ChildrenAction>('moveToRoot');
+  const [targetFolderId, setTargetFolderId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const combobox = useCombobox();
+
+  const { data: allFolders } = useFolders(undefined, opened);
+
+  const folderOptions = useMemo(() => {
+    if (!allFolders || !folder) return [];
+    // Exclude the folder being deleted
+    const excludeIds = new Set([folder.id]);
+    return buildFolderHierarchy(allFolders, excludeIds);
+  }, [allFolders, folder]);
+
+  if (!folder) return null;
+
+  const hasChildren = (folder._count?.children ?? 0) > 0;
+  const hasFiles = (folder._count?.files ?? 0) > 0;
+  const hasContent = hasChildren || hasFiles;
+
+  const getDisplayValue = () => {
+    const selected = folderOptions.find((f) => f.id === targetFolderId);
+    return selected?.path || '';
+  };
+
+  const handleDelete = async () => {
+    setLoading(true);
+
+    const body: any = {
+      delete: 'folder',
+    };
+
+    if (hasContent) {
+      body.childrenAction = childrenAction;
+      if (childrenAction === 'moveToFolder') {
+        if (!targetFolderId) {
+          notifications.show({
+            title: 'No folder selected',
+            message: 'Please select a folder to move contents to',
+            color: 'red',
+          });
+          setLoading(false);
+          return;
+        }
+        body.targetFolderId = targetFolderId;
+      }
+    }
+
+    const { error } = await fetchApi<Response['/api/user/folders/[id]']>(
+      `/api/user/folders/${folder.id}`,
+      'DELETE',
+      body,
+    );
+
+    setLoading(false);
+
+    if (error) {
+      notifications.show({
+        title: 'Failed to delete folder',
+        message: error.error,
+        color: 'red',
+      });
+    } else {
+      notifications.show({
+        title: 'Folder deleted',
+        message: `${folder.name} has been deleted`,
+        color: 'green',
+      });
+      mutate((key: string) => typeof key === 'string' && key.startsWith('/api/user/folders'));
+      onClose();
+    }
+  };
+
+  return (
+    <Modal centered opened={opened} onClose={onClose} title={`Delete "${folder.name}"?`}>
+      <Stack gap='sm'>
+        <Text size='sm' c='red' fw={500}>
+          This action cannot be undone.
+        </Text>
+
+        {hasContent && (
+          <>
+            <Text size='sm'>
+              This folder contains {hasFiles && `${folder._count?.files} file(s)`}
+              {hasChildren && hasFiles && ' and '}
+              {hasChildren && `${folder._count?.children} subfolder(s)`}. What would you like to do with them?
+            </Text>
+
+            <Radio.Group value={childrenAction} onChange={(v) => setChildrenAction(v as ChildrenAction)}>
+              <Stack gap='xs'>
+                <Radio value='moveToRoot' label='Move contents to root folder' />
+                <Radio value='moveToFolder' label='Move contents to another folder' />
+                <Radio
+                  value='cascade'
+                  label={
+                    <Text size='sm' c='red'>
+                      Delete everything (cascade delete)
+                    </Text>
+                  }
+                />
+              </Stack>
+            </Radio.Group>
+
+            {childrenAction === 'moveToFolder' && (
+              <Combobox
+                store={combobox}
+                withinPortal={true}
+                onOptionSubmit={(value) => {
+                  setTargetFolderId(value);
+                  setSearch(folderOptions.find((f) => f.id === value)?.path || '');
+                  combobox.closeDropdown();
+                }}
+              >
+                <Combobox.Target>
+                  <InputBase
+                    label='Target Folder'
+                    placeholder='Select a folder'
+                    rightSection={<Combobox.Chevron />}
+                    value={search || getDisplayValue()}
+                    onChange={(event) => {
+                      combobox.openDropdown();
+                      combobox.updateSelectedOptionIndex();
+                      setSearch(event.currentTarget.value);
+                    }}
+                    onClick={() => {
+                      combobox.openDropdown();
+                      setSearch('');
+                    }}
+                    onFocus={() => {
+                      combobox.openDropdown();
+                      setSearch('');
+                    }}
+                    onBlur={() => {
+                      combobox.closeDropdown();
+                      setSearch('');
+                    }}
+                    rightSectionPointerEvents='none'
+                    required
+                  />
+                </Combobox.Target>
+
+                <Combobox.Dropdown>
+                  <FolderComboboxOptions folderOptions={folderOptions} searchValue={search} />
+                </Combobox.Dropdown>
+              </Combobox>
+            )}
+
+            {childrenAction === 'cascade' && (
+              <Text size='sm' c='red' fw={500}>
+                Warning: This will permanently delete all subfolders and files within this folder.
+              </Text>
+            )}
+          </>
+        )}
+
+        <Button
+          onClick={handleDelete}
+          loading={loading}
+          leftSection={<IconTrashFilled size='1rem' />}
+          color='red'
+        >
+          Delete Folder
+        </Button>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/pages/folders/FolderCard.tsx
+++ b/src/components/pages/folders/FolderCard.tsx
@@ -6,6 +6,9 @@ import {
   IconCopy,
   IconDots,
   IconFiles,
+  IconFolder,
+  IconFolderOpen,
+  IconFolderSymlink,
   IconLock,
   IconLockOpen,
   IconPencil,
@@ -17,43 +20,80 @@ import { useState } from 'react';
 import ViewFilesModal from './ViewFilesModal';
 import { copyFolderUrl, deleteFolder, editFolderUploads, editFolderVisibility } from './actions';
 import EditFolderNameModal from './EditFolderNameModal';
+import MoveFolderModal from './MoveFolderModal';
 
-export default function FolderCard({ folder }: { folder: Folder }) {
+interface FolderCardProps {
+  folder: Folder;
+  onNavigate?: (folderId: string | null) => void;
+}
+
+export default function FolderCard({ folder, onNavigate }: FolderCardProps) {
   const clipboard = useClipboard();
 
   const [viewOpen, setViewOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
+
+  const childrenCount = folder._count?.children ?? 0;
+  const filesCount = folder._count?.files ?? folder.files?.length ?? 0;
 
   return (
     <>
       <ViewFilesModal opened={viewOpen} onClose={() => setViewOpen(false)} folder={folder} />
       <EditFolderNameModal folder={folder} opened={editOpen} onClose={() => setEditOpen(false)} />
+      <MoveFolderModal folder={folder} opened={moveOpen} onClose={() => setMoveOpen(false)} />
 
-      <Card withBorder shadow='sm' radius='sm'>
-        <Card.Section withBorder inheritPadding py='xs'>
+      <Card withBorder shadow='sm' radius='sm' style={{ cursor: onNavigate ? 'pointer' : 'default' }}>
+        <Card.Section
+          withBorder
+          inheritPadding
+          py='xs'
+          onClick={() => onNavigate?.(folder.id)}
+        >
           <Group justify='space-between'>
-            <Text fw={400}>
-              {folder.public ? (
-                <Anchor href={`/folder/${folder.id}`} target='_blank'>
-                  {folder.name}
-                </Anchor>
-              ) : (
-                folder.name
-              )}
-            </Text>
+            <Group gap='xs'>
+              <IconFolder size='1rem' />
+              <Text fw={400}>
+                {folder.public ? (
+                  <Anchor
+                    href={`/folder/${folder.id}`}
+                    target='_blank'
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {folder.name}
+                  </Anchor>
+                ) : (
+                  folder.name
+                )}
+              </Text>
+            </Group>
 
             <Menu withinPortal position='bottom-end' shadow='sm'>
               <Group gap={2}>
                 <Menu.Target>
-                  <ActionIcon variant='transparent'>
+                  <ActionIcon variant='transparent' onClick={(e) => e.stopPropagation()}>
                     <IconDots size='1rem' />
                   </ActionIcon>
                 </Menu.Target>
               </Group>
 
               <Menu.Dropdown>
+                {onNavigate && (
+                  <Menu.Item
+                    leftSection={<IconFolderOpen size='1rem' />}
+                    onClick={() => onNavigate(folder.id)}
+                  >
+                    Open Folder
+                  </Menu.Item>
+                )}
                 <Menu.Item leftSection={<IconFiles size='1rem' />} onClick={() => setViewOpen(true)}>
                   View Files
+                </Menu.Item>
+                <Menu.Item
+                  leftSection={<IconFolderSymlink size='1rem' />}
+                  onClick={() => setMoveOpen(true)}
+                >
+                  Move Folder
                 </Menu.Item>
                 <Menu.Item
                   leftSection={folder.public ? <IconLock size='1rem' /> : <IconLockOpen size='1rem' />}
@@ -89,7 +129,7 @@ export default function FolderCard({ folder }: { folder: Folder }) {
           </Group>
         </Card.Section>
 
-        <Card.Section inheritPadding py='xs'>
+        <Card.Section inheritPadding py='xs' onClick={() => onNavigate?.(folder.id)}>
           <Stack gap={1}>
             <Text size='xs' c='dimmed'>
               <b>Created:</b> <RelativeDate date={folder.createdAt} />
@@ -101,8 +141,13 @@ export default function FolderCard({ folder }: { folder: Folder }) {
               <b>Public:</b> {folder.public ? 'Yes' : 'No'}
             </Text>
             <Text size='xs' c='dimmed'>
-              <b>Files:</b> {folder.files!.length}
+              <b>Files:</b> {filesCount}
             </Text>
+            {childrenCount > 0 && (
+              <Text size='xs' c='dimmed'>
+                <b>Subfolders:</b> {childrenCount}
+              </Text>
+            )}
           </Stack>
         </Card.Section>
       </Card>

--- a/src/components/pages/folders/FolderCard.tsx
+++ b/src/components/pages/folders/FolderCard.tsx
@@ -18,21 +18,24 @@ import {
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import ViewFilesModal from './ViewFilesModal';
-import { copyFolderUrl, deleteFolder, editFolderUploads, editFolderVisibility } from './actions';
+import { copyFolderUrl, editFolderUploads, editFolderVisibility } from './actions';
+import DeleteFolderModal from './DeleteFolderModal';
 import EditFolderNameModal from './EditFolderNameModal';
 import MoveFolderModal from './MoveFolderModal';
 
-interface FolderCardProps {
+export default function FolderCard({
+  folder,
+  onNavigate,
+}: {
   folder: Folder;
   onNavigate?: (folderId: string | null) => void;
-}
-
-export default function FolderCard({ folder, onNavigate }: FolderCardProps) {
+}) {
   const clipboard = useClipboard();
 
   const [viewOpen, setViewOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const childrenCount = folder._count?.children ?? 0;
   const filesCount = folder._count?.files ?? folder.files?.length ?? 0;
@@ -42,6 +45,7 @@ export default function FolderCard({ folder, onNavigate }: FolderCardProps) {
       <ViewFilesModal opened={viewOpen} onClose={() => setViewOpen(false)} folder={folder} />
       <EditFolderNameModal folder={folder} opened={editOpen} onClose={() => setEditOpen(false)} />
       <MoveFolderModal folder={folder} opened={moveOpen} onClose={() => setMoveOpen(false)} />
+      <DeleteFolderModal opened={deleteOpen} folder={folder} onClose={() => setDeleteOpen(false)} />
 
       <Card withBorder shadow='sm' radius='sm' style={{ cursor: onNavigate ? 'pointer' : 'default' }}>
         <Card.Section withBorder inheritPadding py='xs' onClick={() => onNavigate?.(folder.id)}>
@@ -108,7 +112,7 @@ export default function FolderCard({ folder, onNavigate }: FolderCardProps) {
                 <Menu.Item
                   leftSection={<IconTrashFilled size='1rem' />}
                   color='red'
-                  onClick={() => deleteFolder(folder)}
+                  onClick={() => setDeleteOpen(true)}
                 >
                   Delete
                 </Menu.Item>

--- a/src/components/pages/folders/FolderCard.tsx
+++ b/src/components/pages/folders/FolderCard.tsx
@@ -44,22 +44,13 @@ export default function FolderCard({ folder, onNavigate }: FolderCardProps) {
       <MoveFolderModal folder={folder} opened={moveOpen} onClose={() => setMoveOpen(false)} />
 
       <Card withBorder shadow='sm' radius='sm' style={{ cursor: onNavigate ? 'pointer' : 'default' }}>
-        <Card.Section
-          withBorder
-          inheritPadding
-          py='xs'
-          onClick={() => onNavigate?.(folder.id)}
-        >
+        <Card.Section withBorder inheritPadding py='xs' onClick={() => onNavigate?.(folder.id)}>
           <Group justify='space-between'>
             <Group gap='xs'>
               <IconFolder size='1rem' />
               <Text fw={400}>
                 {folder.public ? (
-                  <Anchor
-                    href={`/folder/${folder.id}`}
-                    target='_blank'
-                    onClick={(e) => e.stopPropagation()}
-                  >
+                  <Anchor href={`/folder/${folder.id}`} target='_blank' onClick={(e) => e.stopPropagation()}>
                     {folder.name}
                   </Anchor>
                 ) : (
@@ -89,10 +80,7 @@ export default function FolderCard({ folder, onNavigate }: FolderCardProps) {
                 <Menu.Item leftSection={<IconFiles size='1rem' />} onClick={() => setViewOpen(true)}>
                   View Files
                 </Menu.Item>
-                <Menu.Item
-                  leftSection={<IconFolderSymlink size='1rem' />}
-                  onClick={() => setMoveOpen(true)}
-                >
+                <Menu.Item leftSection={<IconFolderSymlink size='1rem' />} onClick={() => setMoveOpen(true)}>
                   Move Folder
                 </Menu.Item>
                 <Menu.Item

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -1,11 +1,14 @@
+import FolderComboboxOptions from '@/components/folders/FolderComboboxOptions';
 import { Response } from '@/lib/api/response';
 import { Folder } from '@/lib/db/models/folder';
 import { fetchApi } from '@/lib/fetchApi';
-import { Button, Modal, Select, Stack, Text } from '@mantine/core';
+import { buildFolderHierarchy, getDescendantIds } from '@/lib/folderHierarchy';
+import { useFolders } from '@/lib/hooks/useFolders';
+import { Button, Combobox, InputBase, Modal, Stack, Text, useCombobox } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconFolderSymlink } from '@tabler/icons-react';
-import React, { useMemo, useState } from 'react';
-import useSWR, { mutate } from 'swr';
+import { useMemo, useState } from 'react';
+import { mutate } from 'swr';
 
 interface MoveFolderModalProps {
   folder: Folder | null;
@@ -16,79 +19,28 @@ interface MoveFolderModalProps {
 export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderModalProps) {
   const [selectedParentId, setSelectedParentId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState('');
+  const combobox = useCombobox();
 
-  // Fetch all folders to build the selection list
-  const { data: allFolders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
-    opened ? '/api/user/folders?noincl=true' : null,
-  );
-
-  // Reset selected parent when folder changes
-  React.useEffect(() => {
-    if (folder) {
-      setSelectedParentId(folder.parentId ?? null);
-    }
-  }, [folder]);
-
-  // Filter out the current folder and its descendants to prevent circular references
-  const getDescendantIds = (folderId: string, folders: Folder[]): Set<string> => {
-    const descendants = new Set<string>();
-    const addDescendants = (parentId: string) => {
-      for (const f of folders) {
-        if (f.parentId === parentId) {
-          descendants.add(f.id);
-          addDescendants(f.id);
-        }
-      }
-    };
-    addDescendants(folderId);
-    return descendants;
-  };
+  const { data: allFolders } = useFolders(undefined, opened);
 
   const folderOptions = useMemo(() => {
-    if (!allFolders || !folder) return [{ value: '__root__', label: '/ (Root)' }];
+    if (!allFolders || !folder) return [];
 
     const descendantIds = getDescendantIds(folder.id, allFolders);
-    const validFolders = allFolders.filter((f) => f.id !== folder.id && !descendantIds.has(f.id));
+    // Exclude the folder being moved and its descendants
+    const excludeIds = new Set([folder.id, ...descendantIds]);
 
-    // Group children by parent
-    const childrenMap = new Map<string | null, Folder[]>();
-    for (const f of validFolders) {
-      const parentId = f.parentId ?? null;
-      // Skip if parent is excluded (the folder being moved or its descendants)
-      if (parentId && (parentId === folder.id || descendantIds.has(parentId))) continue;
-      const siblings = childrenMap.get(parentId) || [];
-      siblings.push(f);
-      childrenMap.set(parentId, siblings);
-    }
-
-    // Sort children alphabetically within each level
-    for (const children of childrenMap.values()) {
-      children.sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    // Depth-first traversal
-    const result: Array<{ value: string; label: string }> = [];
-
-    const traverse = (f: Folder, pathParts: string[]) => {
-      const currentPath = [...pathParts, f.name];
-      result.push({
-        value: f.id,
-        label: currentPath.join(' / '),
-      });
-
-      const children = childrenMap.get(f.id) || [];
-      for (const child of children) {
-        traverse(child, currentPath);
-      }
-    };
-
-    const rootFolders = childrenMap.get(null) || [];
-    for (const root of rootFolders) {
-      traverse(root, []);
-    }
-
-    return [{ value: '__root__', label: '/ (Root)' }, ...result];
+    return buildFolderHierarchy(allFolders, excludeIds);
   }, [allFolders, folder]);
+
+  const getDisplayValue = () => {
+    if (selectedParentId === '__root__' || selectedParentId === null) {
+      return '/ (Root)';
+    }
+    const selected = folderOptions.find((f) => f.id === selectedParentId);
+    return selected?.path || '';
+  };
 
   if (!folder) {
     return null;
@@ -125,20 +77,58 @@ export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderM
   };
 
   return (
-    <Modal centered opened={opened} onClose={onClose} title={`Move "${folder.name}"`}>
+    <Modal key={folder.id} centered opened={opened} onClose={onClose} title={`Move "${folder.name}"`}>
       <Stack gap='sm'>
         <Text size='sm' c='dimmed'>
           Select a destination folder for this folder.
         </Text>
 
-        <Select
-          label='Destination'
-          placeholder='Select a folder'
-          data={folderOptions}
-          value={selectedParentId ?? '__root__'}
-          onChange={(value) => setSelectedParentId(value)}
-          searchable
-        />
+        <Combobox
+          store={combobox}
+          withinPortal={true}
+          onOptionSubmit={(value) => {
+            setSelectedParentId(value);
+            setSearch(
+              value === '__root__' ? '/ (Root)' : folderOptions.find((f) => f.id === value)?.path || '',
+            );
+            combobox.closeDropdown();
+          }}
+        >
+          <Combobox.Target>
+            <InputBase
+              label='Destination'
+              placeholder='Select a folder'
+              rightSection={<Combobox.Chevron />}
+              value={search || getDisplayValue()}
+              onChange={(event) => {
+                combobox.openDropdown();
+                combobox.updateSelectedOptionIndex();
+                setSearch(event.currentTarget.value);
+              }}
+              onClick={() => {
+                combobox.openDropdown();
+                setSearch('');
+              }}
+              onFocus={() => {
+                combobox.openDropdown();
+                setSearch('');
+              }}
+              onBlur={() => {
+                combobox.closeDropdown();
+                setSearch('');
+              }}
+              rightSectionPointerEvents='none'
+            />
+          </Combobox.Target>
+
+          <Combobox.Dropdown>
+            <FolderComboboxOptions
+              folderOptions={folderOptions}
+              searchValue={search}
+              additionalOptions={<Combobox.Option value='__root__'>/ (Root)</Combobox.Option>}
+            />
+          </Combobox.Dropdown>
+        </Combobox>
 
         <Button
           onClick={handleMove}

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -5,7 +5,7 @@ import { Button, Modal, Select, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconFolderSymlink } from '@tabler/icons-react';
 import { useState } from 'react';
-import useSWR, { mutate } from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 
 interface MoveFolderModalProps {
   folder: Folder;
@@ -14,6 +14,7 @@ interface MoveFolderModalProps {
 }
 
 export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderModalProps) {
+  const { mutate } = useSWRConfig();
   const [selectedParentId, setSelectedParentId] = useState<string | null>(folder.parentId ?? null);
   const [loading, setLoading] = useState(false);
 
@@ -74,7 +75,9 @@ export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderM
         message: `${folder.name} has been moved`,
         color: 'green',
       });
-      mutate((key: string) => typeof key === 'string' && key.startsWith('/api/user/folders'));
+      mutate((key) => typeof key === 'string' && key.startsWith('/api/user/folders'), undefined, {
+        revalidate: true,
+      });
       onClose();
     }
   };

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -7,7 +7,6 @@ import { IconFolderSymlink } from '@tabler/icons-react';
 import React, { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 
-
 interface MoveFolderModalProps {
   folder: Folder | null;
   opened: boolean;

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -4,8 +4,20 @@ import { fetchApi } from '@/lib/fetchApi';
 import { Button, Modal, Select, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconFolderSymlink } from '@tabler/icons-react';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
+
+function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
+  const parts: string[] = [];
+  let current: Folder | undefined = folder;
+
+  while (current) {
+    parts.unshift(current.name);
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return parts.join(' / ');
+}
 
 interface MoveFolderModalProps {
   folder: Folder | null;
@@ -29,10 +41,6 @@ export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderM
     }
   }, [folder]);
 
-  if (!folder) {
-    return null;
-  }
-
   // Filter out the current folder and its descendants to prevent circular references
   const getDescendantIds = (folderId: string, folders: Folder[]): Set<string> => {
     const descendants = new Set<string>();
@@ -48,17 +56,26 @@ export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderM
     return descendants;
   };
 
-  const descendantIds = allFolders ? getDescendantIds(folder.id, allFolders) : new Set<string>();
+  const folderOptions = useMemo(() => {
+    if (!allFolders || !folder) return [{ value: '__root__', label: '/ (Root)' }];
 
-  const folderOptions = [
-    { value: '__root__', label: '/ (Root)' },
-    ...(allFolders
-      ?.filter((f) => f.id !== folder.id && !descendantIds.has(f.id))
+    const foldersMap = new Map(allFolders.map((f) => [f.id, f]));
+    const descendantIds = getDescendantIds(folder.id, allFolders);
+
+    const options = allFolders
+      .filter((f) => f.id !== folder.id && !descendantIds.has(f.id))
       .map((f) => ({
         value: f.id,
-        label: f.name,
-      })) ?? []),
-  ];
+        label: buildFolderPath(f, foldersMap),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    return [{ value: '__root__', label: '/ (Root)' }, ...options];
+  }, [allFolders, folder]);
+
+  if (!folder) {
+    return null;
+  }
 
   const handleMove = async () => {
     setLoading(true);

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -7,17 +7,6 @@ import { IconFolderSymlink } from '@tabler/icons-react';
 import React, { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 
-function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
-  const parts: string[] = [];
-  let current: Folder | undefined = folder;
-
-  while (current) {
-    parts.unshift(current.name);
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return parts.join(' / ');
-}
 
 interface MoveFolderModalProps {
   folder: Folder | null;
@@ -59,18 +48,47 @@ export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderM
   const folderOptions = useMemo(() => {
     if (!allFolders || !folder) return [{ value: '__root__', label: '/ (Root)' }];
 
-    const foldersMap = new Map(allFolders.map((f) => [f.id, f]));
     const descendantIds = getDescendantIds(folder.id, allFolders);
+    const validFolders = allFolders.filter((f) => f.id !== folder.id && !descendantIds.has(f.id));
 
-    const options = allFolders
-      .filter((f) => f.id !== folder.id && !descendantIds.has(f.id))
-      .map((f) => ({
+    // Group children by parent
+    const childrenMap = new Map<string | null, Folder[]>();
+    for (const f of validFolders) {
+      const parentId = f.parentId ?? null;
+      // Skip if parent is excluded (the folder being moved or its descendants)
+      if (parentId && (parentId === folder.id || descendantIds.has(parentId))) continue;
+      const siblings = childrenMap.get(parentId) || [];
+      siblings.push(f);
+      childrenMap.set(parentId, siblings);
+    }
+
+    // Sort children alphabetically within each level
+    for (const children of childrenMap.values()) {
+      children.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Depth-first traversal
+    const result: Array<{ value: string; label: string }> = [];
+
+    const traverse = (f: Folder, pathParts: string[]) => {
+      const currentPath = [...pathParts, f.name];
+      result.push({
         value: f.id,
-        label: buildFolderPath(f, foldersMap),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label));
+        label: currentPath.join(' / '),
+      });
 
-    return [{ value: '__root__', label: '/ (Root)' }, ...options];
+      const children = childrenMap.get(f.id) || [];
+      for (const child of children) {
+        traverse(child, currentPath);
+      }
+    };
+
+    const rootFolders = childrenMap.get(null) || [];
+    for (const root of rootFolders) {
+      traverse(root, []);
+    }
+
+    return [{ value: '__root__', label: '/ (Root)' }, ...result];
   }, [allFolders, folder]);
 
   if (!folder) {

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -4,24 +4,34 @@ import { fetchApi } from '@/lib/fetchApi';
 import { Button, Modal, Select, Stack, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { IconFolderSymlink } from '@tabler/icons-react';
-import { useState } from 'react';
-import useSWR, { useSWRConfig } from 'swr';
+import React, { useState } from 'react';
+import useSWR, { mutate } from 'swr';
 
 interface MoveFolderModalProps {
-  folder: Folder;
+  folder: Folder | null;
   opened: boolean;
   onClose: () => void;
 }
 
 export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderModalProps) {
-  const { mutate } = useSWRConfig();
-  const [selectedParentId, setSelectedParentId] = useState<string | null>(folder.parentId ?? null);
+  const [selectedParentId, setSelectedParentId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Fetch all folders to build the selection list
   const { data: allFolders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
     opened ? '/api/user/folders?noincl=true' : null,
   );
+
+  // Reset selected parent when folder changes
+  React.useEffect(() => {
+    if (folder) {
+      setSelectedParentId(folder.parentId ?? null);
+    }
+  }, [folder]);
+
+  if (!folder) {
+    return null;
+  }
 
   // Filter out the current folder and its descendants to prevent circular references
   const getDescendantIds = (folderId: string, folders: Folder[]): Set<string> => {
@@ -75,9 +85,7 @@ export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderM
         message: `${folder.name} has been moved`,
         color: 'green',
       });
-      mutate((key) => typeof key === 'string' && key.startsWith('/api/user/folders'), undefined, {
-        revalidate: true,
-      });
+      mutate((key: string) => typeof key === 'string' && key.startsWith('/api/user/folders'));
       onClose();
     }
   };

--- a/src/components/pages/folders/MoveFolderModal.tsx
+++ b/src/components/pages/folders/MoveFolderModal.tsx
@@ -1,0 +1,109 @@
+import { Response } from '@/lib/api/response';
+import { Folder } from '@/lib/db/models/folder';
+import { fetchApi } from '@/lib/fetchApi';
+import { Button, Modal, Select, Stack, Text } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconFolderSymlink } from '@tabler/icons-react';
+import { useState } from 'react';
+import useSWR, { mutate } from 'swr';
+
+interface MoveFolderModalProps {
+  folder: Folder;
+  opened: boolean;
+  onClose: () => void;
+}
+
+export default function MoveFolderModal({ folder, opened, onClose }: MoveFolderModalProps) {
+  const [selectedParentId, setSelectedParentId] = useState<string | null>(folder.parentId ?? null);
+  const [loading, setLoading] = useState(false);
+
+  // Fetch all folders to build the selection list
+  const { data: allFolders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
+    opened ? '/api/user/folders?noincl=true' : null,
+  );
+
+  // Filter out the current folder and its descendants to prevent circular references
+  const getDescendantIds = (folderId: string, folders: Folder[]): Set<string> => {
+    const descendants = new Set<string>();
+    const addDescendants = (parentId: string) => {
+      for (const f of folders) {
+        if (f.parentId === parentId) {
+          descendants.add(f.id);
+          addDescendants(f.id);
+        }
+      }
+    };
+    addDescendants(folderId);
+    return descendants;
+  };
+
+  const descendantIds = allFolders ? getDescendantIds(folder.id, allFolders) : new Set<string>();
+
+  const folderOptions = [
+    { value: '__root__', label: '/ (Root)' },
+    ...(allFolders
+      ?.filter((f) => f.id !== folder.id && !descendantIds.has(f.id))
+      .map((f) => ({
+        value: f.id,
+        label: f.name,
+      })) ?? []),
+  ];
+
+  const handleMove = async () => {
+    setLoading(true);
+
+    const newParentId = selectedParentId === '__root__' ? null : selectedParentId;
+
+    const { error } = await fetchApi<Response['/api/user/folders/[id]']>(
+      `/api/user/folders/${folder.id}`,
+      'PATCH',
+      { parentId: newParentId },
+    );
+
+    setLoading(false);
+
+    if (error) {
+      notifications.show({
+        title: 'Failed to move folder',
+        message: error.error,
+        color: 'red',
+      });
+    } else {
+      notifications.show({
+        title: 'Folder moved',
+        message: `${folder.name} has been moved`,
+        color: 'green',
+      });
+      mutate((key: string) => typeof key === 'string' && key.startsWith('/api/user/folders'));
+      onClose();
+    }
+  };
+
+  return (
+    <Modal centered opened={opened} onClose={onClose} title={`Move "${folder.name}"`}>
+      <Stack gap='sm'>
+        <Text size='sm' c='dimmed'>
+          Select a destination folder for this folder.
+        </Text>
+
+        <Select
+          label='Destination'
+          placeholder='Select a folder'
+          data={folderOptions}
+          value={selectedParentId ?? '__root__'}
+          onChange={(value) => setSelectedParentId(value)}
+          searchable
+        />
+
+        <Button
+          onClick={handleMove}
+          loading={loading}
+          leftSection={<IconFolderSymlink size='1rem' />}
+          variant='outline'
+        >
+          Move Folder
+        </Button>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/pages/folders/actions.tsx
+++ b/src/components/pages/folders/actions.tsx
@@ -3,26 +3,10 @@ import { Folder } from '@/lib/db/models/folder';
 import { fetchApi } from '@/lib/fetchApi';
 import { Anchor } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
-import { modals } from '@mantine/modals';
 import { notifications } from '@mantine/notifications';
 import { IconCheck, IconCopy, IconFolderOff } from '@tabler/icons-react';
 import { Link } from 'react-router-dom';
 import { mutate } from 'swr';
-
-export async function deleteFolder(folder: Folder) {
-  modals.openConfirmModal({
-    centered: true,
-    title: `Delete ${folder.name}?`,
-    children: `Are you sure you want to delete ${folder.name}? This action cannot be undone.`,
-    labels: {
-      cancel: 'Cancel',
-      confirm: 'Delete',
-    },
-    confirmProps: { color: 'red' },
-    onConfirm: () => handleDeleteFolder(folder),
-    onCancel: modals.closeAll,
-  });
-}
 
 export function copyFolderUrl(folder: Folder, clipboard: ReturnType<typeof useClipboard>) {
   clipboard.copy(`${window.location.protocol}//${window.location.host}/folder/${folder.id}`);
@@ -87,34 +71,6 @@ export async function editFolderUploads(folder: Folder, allowUploads: boolean) {
     notifications.show({
       title: 'Folder uploads policy edited',
       message: `${data?.name} will ${allowUploads ? 'now' : 'no longer'} allow anonymous uploads`,
-      color: 'green',
-      icon: <IconCheck size='1rem' />,
-    });
-  }
-
-  mutate('/api/user/folders');
-}
-
-async function handleDeleteFolder(folder: Folder) {
-  const { data, error } = await fetchApi<Response['/api/user/folders/[id]']>(
-    `/api/user/folders/${folder.id}`,
-    'DELETE',
-    {
-      delete: 'folder',
-    },
-  );
-
-  if (error) {
-    notifications.show({
-      title: 'Failed to delete folder',
-      message: error.error,
-      color: 'red',
-      icon: <IconFolderOff size='1rem' />,
-    });
-  } else {
-    notifications.show({
-      title: 'Folder deleted',
-      message: `${data?.name} has been deleted`,
       color: 'green',
       icon: <IconCheck size='1rem' />,
     });

--- a/src/components/pages/folders/index.tsx
+++ b/src/components/pages/folders/index.tsx
@@ -79,14 +79,14 @@ export default function DashboardFolders() {
 
     if (currentFolder) {
       // Walk up parent chain
-      const path: Folder[] = [];
-      let folder: Folder | undefined | null = currentFolder;
+      const path: Partial<Folder>[] = [];
+      let folder: Partial<Folder> | undefined | null = currentFolder;
       while (folder) {
         path.unshift(folder);
         folder = folder.parent;
       }
       for (const f of path) {
-        items.push({ id: f.id, name: f.name });
+        items.push({ id: f.id!, name: f.name! });
       }
     }
 

--- a/src/components/pages/folders/index.tsx
+++ b/src/components/pages/folders/index.tsx
@@ -3,12 +3,25 @@ import { Response } from '@/lib/api/response';
 import { Folder } from '@/lib/db/models/folder';
 import { fetchApi } from '@/lib/fetchApi';
 import { useViewStore } from '@/lib/store/view';
-import { Button, Group, Modal, Stack, Switch, TextInput, Title } from '@mantine/core';
+import {
+  ActionIcon,
+  Anchor,
+  Breadcrumbs,
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Switch,
+  TextInput,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
-import { IconFolderPlus } from '@tabler/icons-react';
-import { useState } from 'react';
+import { IconFolderPlus, IconHome, IconPlus } from '@tabler/icons-react';
+import { useState, useCallback } from 'react';
 import { mutate } from 'swr';
+import useSWR from 'swr';
 import FolderGridView from './views/FolderGridView';
 import FolderTableView from './views/FolderTableView';
 
@@ -16,6 +29,12 @@ export default function DashboardFolders() {
   const view = useViewStore((state) => state.folders);
 
   const [open, setOpen] = useState(false);
+  const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
+
+  // Fetch current folder details for breadcrumb
+  const { data: currentFolder } = useSWR<Folder>(
+    currentFolderId ? `/api/user/folders/${currentFolderId}` : null,
+  );
 
   const form = useForm({
     initialValues: {
@@ -34,6 +53,7 @@ export default function DashboardFolders() {
       {
         name: values.name,
         isPublic: values.isPublic,
+        parentId: currentFolderId ?? undefined,
       },
     );
 
@@ -43,15 +63,46 @@ export default function DashboardFolders() {
         color: 'red',
       });
     } else {
-      mutate('/api/user/folders');
+      mutate((key: string) => key.startsWith('/api/user/folders'));
       setOpen(false);
       form.reset();
     }
   };
 
+  const navigateToFolder = useCallback((folderId: string | null) => {
+    setCurrentFolderId(folderId);
+  }, []);
+
+  // Build breadcrumb path from current folder
+  const buildBreadcrumbs = () => {
+    const items: { id: string | null; name: string }[] = [{ id: null, name: 'Root' }];
+
+    if (currentFolder) {
+      // Walk up parent chain
+      const path: Folder[] = [];
+      let folder: Folder | undefined | null = currentFolder;
+      while (folder) {
+        path.unshift(folder);
+        folder = folder.parent;
+      }
+      for (const f of path) {
+        items.push({ id: f.id, name: f.name });
+      }
+    }
+
+    return items;
+  };
+
+  const breadcrumbs = buildBreadcrumbs();
+
   return (
     <>
-      <Modal centered opened={open} onClose={() => setOpen(false)} title='Create a folder'>
+      <Modal
+        centered
+        opened={open}
+        onClose={() => setOpen(false)}
+        title={currentFolderId ? 'Create a subfolder' : 'Create a folder'}
+      >
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack gap='sm'>
             <TextInput label='Name' placeholder='Enter a name...' {...form.getInputProps('name')} />
@@ -71,19 +122,35 @@ export default function DashboardFolders() {
       <Group>
         <Title>Folders</Title>
 
-        <Button
-          size='compact-sm'
-          variant='outline'
-          leftSection={<IconFolderPlus size='1rem' />}
-          onClick={() => setOpen(true)}
-        >
-          Create
-        </Button>
+        <Tooltip label={currentFolderId ? 'Create a subfolder' : 'Create a new folder'}>
+          <ActionIcon variant='outline' onClick={() => setOpen(true)}>
+            <IconPlus size='1rem' />
+          </ActionIcon>
+        </Tooltip>
 
         <GridTableSwitcher type='folders' />
       </Group>
 
-      {view === 'grid' ? <FolderGridView /> : <FolderTableView />}
+      {breadcrumbs.length > 1 && (
+        <Breadcrumbs my='sm'>
+          {breadcrumbs.map((item, index) => (
+            <Anchor
+              key={item.id ?? 'root'}
+              onClick={() => navigateToFolder(item.id)}
+              style={{ cursor: 'pointer' }}
+              fw={index === breadcrumbs.length - 1 ? 600 : 400}
+            >
+              {index === 0 ? <IconHome size='1rem' /> : item.name}
+            </Anchor>
+          ))}
+        </Breadcrumbs>
+      )}
+
+      {view === 'grid' ? (
+        <FolderGridView currentFolderId={currentFolderId} onNavigate={navigateToFolder} />
+      ) : (
+        <FolderTableView currentFolderId={currentFolderId} onNavigate={navigateToFolder} />
+      )}
     </>
   );
 }

--- a/src/components/pages/folders/index.tsx
+++ b/src/components/pages/folders/index.tsx
@@ -20,13 +20,13 @@ import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { IconFolderPlus, IconHome, IconPlus } from '@tabler/icons-react';
 import { useState, useCallback } from 'react';
-import useSWR, { useSWRConfig } from 'swr';
+import { mutate } from 'swr';
+import useSWR from 'swr';
 import FolderGridView from './views/FolderGridView';
 import FolderTableView from './views/FolderTableView';
 
 export default function DashboardFolders() {
   const view = useViewStore((state) => state.folders);
-  const { mutate } = useSWRConfig();
 
   const [open, setOpen] = useState(false);
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
@@ -63,9 +63,7 @@ export default function DashboardFolders() {
         color: 'red',
       });
     } else {
-      mutate((key) => typeof key === 'string' && key.startsWith('/api/user/folders'), undefined, {
-        revalidate: true,
-      });
+      mutate((key: string) => key.startsWith('/api/user/folders'));
       setOpen(false);
       form.reset();
     }

--- a/src/components/pages/folders/index.tsx
+++ b/src/components/pages/folders/index.tsx
@@ -20,13 +20,13 @@ import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { IconFolderPlus, IconHome, IconPlus } from '@tabler/icons-react';
 import { useState, useCallback } from 'react';
-import { mutate } from 'swr';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 import FolderGridView from './views/FolderGridView';
 import FolderTableView from './views/FolderTableView';
 
 export default function DashboardFolders() {
   const view = useViewStore((state) => state.folders);
+  const { mutate } = useSWRConfig();
 
   const [open, setOpen] = useState(false);
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
@@ -63,7 +63,9 @@ export default function DashboardFolders() {
         color: 'red',
       });
     } else {
-      mutate((key: string) => key.startsWith('/api/user/folders'));
+      mutate((key) => typeof key === 'string' && key.startsWith('/api/user/folders'), undefined, {
+        revalidate: true,
+      });
       setOpen(false);
       form.reset();
     }

--- a/src/components/pages/folders/index.tsx
+++ b/src/components/pages/folders/index.tsx
@@ -19,7 +19,8 @@ import {
 import { useForm } from '@mantine/form';
 import { notifications } from '@mantine/notifications';
 import { IconFolderPlus, IconHome, IconPlus } from '@tabler/icons-react';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { mutate } from 'swr';
 import useSWR from 'swr';
 import FolderGridView from './views/FolderGridView';
@@ -27,11 +28,19 @@ import FolderTableView from './views/FolderTableView';
 
 export default function DashboardFolders() {
   const view = useViewStore((state) => state.folders);
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const [open, setOpen] = useState(false);
-  const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
 
-  // Fetch current folder details for breadcrumb
+  const folderPath = useMemo(() => {
+    const pathname = location.pathname.replace('/dashboard/folders', '');
+    if (!pathname || pathname === '/') return [];
+    return pathname.split('/').filter(Boolean);
+  }, [location.pathname]);
+
+  const currentFolderId = folderPath.length > 0 ? folderPath[folderPath.length - 1] : null;
+
   const { data: currentFolder } = useSWR<Folder>(
     currentFolderId ? `/api/user/folders/${currentFolderId}` : null,
   );
@@ -69,24 +78,39 @@ export default function DashboardFolders() {
     }
   };
 
-  const navigateToFolder = useCallback((folderId: string | null) => {
-    setCurrentFolderId(folderId);
-  }, []);
+  const navigateToFolder = useCallback(
+    (folderId: string | null) => {
+      if (folderId === null) {
+        navigate('/dashboard/folders');
+      } else {
+        const newPath = [...folderPath, folderId];
+        navigate(`/dashboard/folders/${newPath.join('/')}`);
+      }
+    },
+    [navigate, folderPath],
+  );
 
-  // Build breadcrumb path from current folder
   const buildBreadcrumbs = () => {
-    const items: { id: string | null; name: string }[] = [{ id: null, name: 'Root' }];
+    const items: { id: string | null; name: string; path: string }[] = [
+      { id: null, name: 'Root', path: '/dashboard/folders' },
+    ];
 
     if (currentFolder) {
-      // Walk up parent chain
       const path: Partial<Folder>[] = [];
       let folder: Partial<Folder> | undefined | null = currentFolder;
       while (folder) {
         path.unshift(folder);
         folder = folder.parent;
       }
+
+      const folderIds: string[] = [];
       for (const f of path) {
-        items.push({ id: f.id!, name: f.name! });
+        folderIds.push(f.id!);
+        items.push({
+          id: f.id!,
+          name: f.name!,
+          path: `/dashboard/folders/${folderIds.join('/')}`,
+        });
       }
     }
 
@@ -136,7 +160,7 @@ export default function DashboardFolders() {
           {breadcrumbs.map((item, index) => (
             <Anchor
               key={item.id ?? 'root'}
-              onClick={() => navigateToFolder(item.id)}
+              onClick={() => navigate(item.path)}
               style={{ cursor: 'pointer' }}
               fw={index === breadcrumbs.length - 1 ? 600 : 400}
             >

--- a/src/components/pages/folders/views/FolderGridView.tsx
+++ b/src/components/pages/folders/views/FolderGridView.tsx
@@ -1,13 +1,20 @@
 import { Response } from '@/lib/api/response';
 import { Folder } from '@/lib/db/models/folder';
 import { Center, Group, Paper, SimpleGrid, Skeleton, Stack, Text, Title } from '@mantine/core';
-import { IconLink } from '@tabler/icons-react';
+import { IconFolder } from '@tabler/icons-react';
 import useSWR from 'swr';
 import FolderCard from '../FolderCard';
 
-export default function FolderGridView() {
-  const { data: folders, isLoading } =
-    useSWR<Extract<Response['/api/user/folders'], Folder[]>>('/api/user/folders');
+interface FolderGridViewProps {
+  currentFolderId: string | null;
+  onNavigate: (folderId: string | null) => void;
+}
+
+export default function FolderGridView({ currentFolderId, onNavigate }: FolderGridViewProps) {
+  const queryParam = currentFolderId ? `?parentId=${currentFolderId}` : '?root=true';
+  const { data: folders, isLoading } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
+    `/api/user/folders${queryParam}`,
+  );
 
   return (
     <>
@@ -26,7 +33,7 @@ export default function FolderGridView() {
             <Skeleton key={i} height={120} animate />
           ))}
         </SimpleGrid>
-      ) : (folders?.length ?? 0 !== 0) ? (
+      ) : (folders?.length ?? 0) !== 0 ? (
         <SimpleGrid
           my='sm'
           spacing='md'
@@ -38,7 +45,7 @@ export default function FolderGridView() {
           pos='relative'
         >
           {folders?.map((folder) => (
-            <FolderCard key={folder.id} folder={folder} />
+            <FolderCard key={folder.id} folder={folder} onNavigate={onNavigate} />
           ))}
         </SimpleGrid>
       ) : (
@@ -46,11 +53,11 @@ export default function FolderGridView() {
           <Center>
             <Stack>
               <Group>
-                <IconLink size='2rem' />
+                <IconFolder size='2rem' />
                 <Title order={2}>No Folders found</Title>
               </Group>
               <Text size='sm' c='dimmed'>
-                Create a folder to see it here
+                {currentFolderId ? 'This folder is empty' : 'Create a folder to see it here'}
               </Text>
             </Stack>
           </Center>

--- a/src/components/pages/folders/views/FolderGridView.tsx
+++ b/src/components/pages/folders/views/FolderGridView.tsx
@@ -5,12 +5,13 @@ import { IconFolder } from '@tabler/icons-react';
 import useSWR from 'swr';
 import FolderCard from '../FolderCard';
 
-interface FolderGridViewProps {
+export default function FolderGridView({
+  currentFolderId,
+  onNavigate,
+}: {
   currentFolderId: string | null;
   onNavigate: (folderId: string | null) => void;
-}
-
-export default function FolderGridView({ currentFolderId, onNavigate }: FolderGridViewProps) {
+}) {
   const queryParam = currentFolderId ? `?parentId=${currentFolderId}` : '?root=true';
   const { data: folders, isLoading } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
     `/api/user/folders${queryParam}`,

--- a/src/components/pages/folders/views/FolderTableView.tsx
+++ b/src/components/pages/folders/views/FolderTableView.tsx
@@ -1,7 +1,7 @@
 import RelativeDate from '@/components/RelativeDate';
 import { Response } from '@/lib/api/response';
 import { Folder } from '@/lib/db/models/folder';
-import { ActionIcon, Anchor, Badge, Box, Checkbox, Group, Tooltip } from '@mantine/core';
+import { ActionIcon, Badge, Box, Checkbox, Group, Text, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
   IconCopy,
@@ -20,17 +20,19 @@ import {
 import { DataTable, DataTableSortStatus } from 'mantine-datatable';
 import { useMemo, useState } from 'react';
 import useSWR from 'swr';
-import { copyFolderUrl, deleteFolder, editFolderUploads, editFolderVisibility } from '../actions';
+import { copyFolderUrl, editFolderUploads, editFolderVisibility } from '../actions';
+import DeleteFolderModal from '../DeleteFolderModal';
 import EditFolderNameModal from '../EditFolderNameModal';
 import MoveFolderModal from '../MoveFolderModal';
 import ViewFilesModal from '../ViewFilesModal';
 
-interface FolderTableViewProps {
+export default function FolderTableView({
+  currentFolderId,
+  onNavigate,
+}: {
   currentFolderId: string | null;
   onNavigate: (folderId: string | null) => void;
-}
-
-export default function FolderTableView({ currentFolderId, onNavigate }: FolderTableViewProps) {
+}) {
   const clipboard = useClipboard();
 
   const queryParam = currentFolderId ? `?parentId=${currentFolderId}` : '?root=true';
@@ -45,6 +47,7 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [editNameOpen, setEditNameOpen] = useState<Folder | null>(null);
   const [moveOpen, setMoveOpen] = useState<Folder | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState<Folder | null>(null);
 
   const sorted = useMemo<Folder[]>(() => {
     if (!data) return [];
@@ -77,6 +80,8 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
 
       <MoveFolderModal opened={!!moveOpen} folder={moveOpen} onClose={() => setMoveOpen(null)} />
 
+      <DeleteFolderModal opened={!!deleteOpen} folder={deleteOpen} onClose={() => setDeleteOpen(null)} />
+
       <Box my='sm'>
         <DataTable
           borderRadius='sm'
@@ -92,17 +97,7 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
               render: (folder) => (
                 <Group gap='xs'>
                   <IconFolder size='1rem' />
-                  {folder.public ? (
-                    <Anchor
-                      href={`/folder/${folder.id}`}
-                      target='_blank'
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {folder.name}
-                    </Anchor>
-                  ) : (
-                    folder.name
-                  )}
+                  <Text>{folder.name}</Text>
                   {(folder._count?.children ?? 0) > 0 && (
                     <Badge size='xs' variant='light'>
                       {folder._count?.children} subfolder{(folder._count?.children ?? 0) > 1 ? 's' : ''}
@@ -139,16 +134,18 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
               textAlign: 'right',
               render: (folder) => (
                 <Group gap='sm' justify='right' wrap='nowrap'>
-                  <Tooltip label='Open folder'>
-                    <ActionIcon
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onNavigate(folder.id);
-                      }}
-                    >
-                      <IconFolderOpen size='1rem' />
-                    </ActionIcon>
-                  </Tooltip>
+                  {folder.public && (
+                    <Tooltip label='Open public link'>
+                      <ActionIcon
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          window.open(`/folder/${folder.id}`, '_blank');
+                        }}
+                      >
+                        <IconFolderOpen size='1rem' />
+                      </ActionIcon>
+                    </Tooltip>
+                  )}
                   <Tooltip label='View files'>
                     <ActionIcon
                       onClick={(e) => {
@@ -231,7 +228,7 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
                       color='red'
                       onClick={(e) => {
                         e.stopPropagation();
-                        deleteFolder(folder);
+                        setDeleteOpen(folder);
                       }}
                     >
                       <IconTrashFilled size='1rem' />

--- a/src/components/pages/folders/views/FolderTableView.tsx
+++ b/src/components/pages/folders/views/FolderTableView.tsx
@@ -75,7 +75,7 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
         onClose={() => setEditNameOpen(null)}
       />
 
-      <MoveFolderModal opened={!!moveOpen} folder={moveOpen!} onClose={() => setMoveOpen(null)} />
+      <MoveFolderModal opened={!!moveOpen} folder={moveOpen} onClose={() => setMoveOpen(null)} />
 
       <Box my='sm'>
         <DataTable

--- a/src/components/pages/folders/views/FolderTableView.tsx
+++ b/src/components/pages/folders/views/FolderTableView.tsx
@@ -1,11 +1,14 @@
 import RelativeDate from '@/components/RelativeDate';
 import { Response } from '@/lib/api/response';
 import { Folder } from '@/lib/db/models/folder';
-import { ActionIcon, Anchor, Box, Checkbox, Group, Tooltip } from '@mantine/core';
+import { ActionIcon, Anchor, Badge, Box, Checkbox, Group, Tooltip } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
   IconCopy,
   IconFiles,
+  IconFolder,
+  IconFolderOpen,
+  IconFolderSymlink,
   IconLock,
   IconLockOpen,
   IconPencil,
@@ -19,12 +22,21 @@ import { useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { copyFolderUrl, deleteFolder, editFolderUploads, editFolderVisibility } from '../actions';
 import EditFolderNameModal from '../EditFolderNameModal';
+import MoveFolderModal from '../MoveFolderModal';
 import ViewFilesModal from '../ViewFilesModal';
 
-export default function FolderTableView() {
+interface FolderTableViewProps {
+  currentFolderId: string | null;
+  onNavigate: (folderId: string | null) => void;
+}
+
+export default function FolderTableView({ currentFolderId, onNavigate }: FolderTableViewProps) {
   const clipboard = useClipboard();
 
-  const { data, isLoading } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>('/api/user/folders');
+  const queryParam = currentFolderId ? `?parentId=${currentFolderId}` : '?root=true';
+  const { data, isLoading } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
+    `/api/user/folders${queryParam}`,
+  );
 
   const [sortStatus, setSortStatus] = useState<DataTableSortStatus>({
     columnAccessor: 'createdAt',
@@ -32,6 +44,7 @@ export default function FolderTableView() {
   });
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [editNameOpen, setEditNameOpen] = useState<Folder | null>(null);
+  const [moveOpen, setMoveOpen] = useState<Folder | null>(null);
 
   const sorted = useMemo<Folder[]>(() => {
     if (!data) return [];
@@ -62,35 +75,56 @@ export default function FolderTableView() {
         onClose={() => setEditNameOpen(null)}
       />
 
+      <MoveFolderModal
+        opened={!!moveOpen}
+        folder={moveOpen!}
+        onClose={() => setMoveOpen(null)}
+      />
+
       <Box my='sm'>
         <DataTable
           borderRadius='sm'
           withTableBorder
           minHeight={200}
           records={sorted ?? []}
+          onRowClick={({ record }) => onNavigate(record.id)}
+          rowStyle={{ cursor: 'pointer' }}
           columns={[
             {
               accessor: 'name',
               sortable: true,
-              render: (folder) =>
-                folder.public ? (
-                  <Anchor href={`/folder/${folder.id}`} target='_blank'>
-                    {folder.name}
-                  </Anchor>
-                ) : (
-                  folder.name
-                ),
+              render: (folder) => (
+                <Group gap='xs'>
+                  <IconFolder size='1rem' />
+                  {folder.public ? (
+                    <Anchor
+                      href={`/folder/${folder.id}`}
+                      target='_blank'
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {folder.name}
+                    </Anchor>
+                  ) : (
+                    folder.name
+                  )}
+                  {(folder._count?.children ?? 0) > 0 && (
+                    <Badge size='xs' variant='light'>
+                      {folder._count?.children} subfolder{(folder._count?.children ?? 0) > 1 ? 's' : ''}
+                    </Badge>
+                  )}
+                </Group>
+              ),
             },
             {
               accessor: 'public',
               sortable: true,
-              render: (folder) => <Checkbox checked={folder.public} />,
+              render: (folder) => <Checkbox checked={folder.public} readOnly />,
             },
             {
               accessor: 'allowUploads',
               title: 'Uploads?',
               sortable: true,
-              render: (folder) => <Checkbox checked={folder.allowUploads} />,
+              render: (folder) => <Checkbox checked={folder.allowUploads} readOnly />,
             },
             {
               accessor: 'createdAt',
@@ -109,6 +143,16 @@ export default function FolderTableView() {
               textAlign: 'right',
               render: (folder) => (
                 <Group gap='sm' justify='right' wrap='nowrap'>
+                  <Tooltip label='Open folder'>
+                    <ActionIcon
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onNavigate(folder.id);
+                      }}
+                    >
+                      <IconFolderOpen size='1rem' />
+                    </ActionIcon>
+                  </Tooltip>
                   <Tooltip label='View files'>
                     <ActionIcon
                       onClick={(e) => {
@@ -117,6 +161,16 @@ export default function FolderTableView() {
                       }}
                     >
                       <IconFiles size='1rem' />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label='Move folder'>
+                    <ActionIcon
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMoveOpen(folder);
+                      }}
+                    >
+                      <IconFolderSymlink size='1rem' />
                     </ActionIcon>
                   </Tooltip>
                   <Tooltip label='Copy folder link'>
@@ -168,7 +222,10 @@ export default function FolderTableView() {
                   <Tooltip label='Export folder as ZIP'>
                     <ActionIcon
                       color='blue'
-                      onClick={() => window.open(`/api/user/folders/${folder.id}/export`, '_blank')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        window.open(`/api/user/folders/${folder.id}/export`, '_blank');
+                      }}
                     >
                       <IconZip size='1rem' />
                     </ActionIcon>

--- a/src/components/pages/folders/views/FolderTableView.tsx
+++ b/src/components/pages/folders/views/FolderTableView.tsx
@@ -84,7 +84,7 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
           minHeight={200}
           records={sorted ?? []}
           onRowClick={({ record }) => onNavigate(record.id)}
-          rowStyle={{ cursor: 'pointer' }}
+          rowStyle={() => ({ cursor: 'pointer' })}
           columns={[
             {
               accessor: 'name',

--- a/src/components/pages/folders/views/FolderTableView.tsx
+++ b/src/components/pages/folders/views/FolderTableView.tsx
@@ -75,11 +75,7 @@ export default function FolderTableView({ currentFolderId, onNavigate }: FolderT
         onClose={() => setEditNameOpen(null)}
       />
 
-      <MoveFolderModal
-        opened={!!moveOpen}
-        folder={moveOpen!}
-        onClose={() => setMoveOpen(null)}
-      />
+      <MoveFolderModal opened={!!moveOpen} folder={moveOpen!} onClose={() => setMoveOpen(null)} />
 
       <Box my='sm'>
         <DataTable

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -45,7 +45,6 @@ function checkDomains(domains?: unknown): string[] {
   return domains;
 }
 
-
 export default function UploadOptionsButton({ folder, numFiles }: { folder?: string; numFiles: number }) {
   const config = useConfig();
 

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -45,6 +45,18 @@ function checkDomains(domains?: unknown): string[] {
   return domains;
 }
 
+function getFolderDepth(folder: Folder, foldersMap: Map<string, Folder>): number {
+  let depth = 0;
+  let current: Folder | undefined = folder.parentId ? foldersMap.get(folder.parentId) : undefined;
+
+  while (current) {
+    depth++;
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return depth;
+}
+
 function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
   const parts: string[] = [];
   let current: Folder | undefined = folder;
@@ -101,7 +113,7 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
         id: f.id,
         name: f.name,
         path: buildFolderPath(f, foldersMap),
-        depth: buildFolderPath(f, foldersMap).split(' / ').length - 1,
+        depth: getFolderDepth(f, foldersMap),
       }))
       .sort((a, b) => a.path.localeCompare(b.path));
   }, [folders]);

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -1,7 +1,9 @@
 import { useConfig } from '@/components/ConfigProvider';
 import DomainSelect from '@/components/DomainSelect';
+import FolderComboboxOptions from '@/components/folders/FolderComboboxOptions';
 import { Response } from '@/lib/api/response';
-import { Folder } from '@/lib/db/models/folder';
+import { buildFolderHierarchy } from '@/lib/folderHierarchy';
+import { useFolders } from '@/lib/hooks/useFolders';
 import { useUploadOptionsStore } from '@/lib/store/uploadOptions';
 import {
   Badge,
@@ -37,14 +39,6 @@ import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 import { useShallow } from 'zustand/shallow';
 
-
-function checkDomains(domains?: unknown): string[] {
-  if (!domains) return [];
-  if (!Array.isArray(domains)) return [];
-
-  return domains;
-}
-
 export default function UploadOptionsButton({ folder, numFiles }: { folder?: string; numFiles: number }) {
   const config = useConfig();
 
@@ -68,56 +62,15 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
     setFolderSearch('');
   };
 
-  const { data: folders } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
-    '/api/user/folders?noincl=true',
-  );
+  const { data: folders } = useFolders();
   const { data: settingsData } = useSWR<Response['/api/server/public']>('/api/server/public');
 
   const combobox = useCombobox();
   const [folderSearch, setFolderSearch] = useState('');
 
-  // Build folder options with hierarchy using depth-first traversal
   const folderOptions = useMemo(() => {
     if (!folders) return [];
-
-    // Group children by parent
-    const childrenMap = new Map<string | null, Folder[]>();
-    for (const folder of folders) {
-      const parentId = folder.parentId ?? null;
-      const siblings = childrenMap.get(parentId) || [];
-      siblings.push(folder);
-      childrenMap.set(parentId, siblings);
-    }
-
-    // Sort children alphabetically within each level
-    for (const children of childrenMap.values()) {
-      children.sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    // Depth-first traversal to build ordered list
-    const result: Array<{ id: string; name: string; path: string; depth: number }> = [];
-
-    const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
-      const currentPath = [...pathParts, folder.name];
-      result.push({
-        id: folder.id,
-        name: folder.name,
-        path: currentPath.join(' / '),
-        depth,
-      });
-
-      const children = childrenMap.get(folder.id) || [];
-      for (const child of children) {
-        traverse(child, depth + 1, currentPath);
-      }
-    };
-
-    const rootFolders = childrenMap.get(null) || [];
-    for (const root of rootFolders) {
-      traverse(root, 0, []);
-    }
-
-    return result;
+    return buildFolderHierarchy(folders);
   }, [folders]);
 
   const expirations = useMemo(() => {
@@ -181,9 +134,14 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
   useEffect(() => {
     if (folder) return;
 
+    // Set initial value
+    if (ephemeral.folderId === null) {
+      setFolderSearch('/ (Root)');
+    }
+
     useUploadOptionsStore.subscribe(
       (state) => state.ephemeral,
-      (current) => (current.folderId === null ? setFolderSearch('') : null),
+      (current) => (current.folderId === null ? setFolderSearch('/ (Root)') : null),
     );
   }, []);
 
@@ -353,9 +311,14 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
             store={combobox}
             withinPortal={false}
             onOptionSubmit={(value) => {
-              const selected = folderOptions.find((f) => f.id === value);
-              setFolderSearch(selected?.path || '');
-              setEphemeral('folderId', value === 'no folder' || value === '' ? null : value);
+              if (value === '__root__') {
+                setFolderSearch('/ (Root)');
+                setEphemeral('folderId', null);
+              } else {
+                const selected = folderOptions.find((f) => f.id === value);
+                setFolderSearch(selected?.path || '');
+                setEphemeral('folderId', value);
+              }
               combobox.closeDropdown();
             }}
             disabled={!!folder}
@@ -363,7 +326,7 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
             <Combobox.Target>
               <InputBase
                 label={<>Add to a Folder</>}
-                description='Add this file to a folder. Use the "no folder" option not add the file to a folder. This value is not saved to your browser, and is cleared after uploading.'
+                description='Add this file to a folder. Use the "/ (Root)" option to not add the file to a folder. This value is not saved to your browser, and is cleared after uploading.'
                 rightSection={<Combobox.Chevron />}
                 leftSection={<IconFolderPlus size='1rem' />}
                 value={folderSearch}
@@ -372,11 +335,23 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
                   combobox.updateSelectedOptionIndex();
                   setFolderSearch(event.currentTarget.value);
                 }}
-                onClick={() => combobox.openDropdown()}
-                onFocus={() => combobox.openDropdown()}
+                onClick={() => {
+                  combobox.openDropdown();
+                  setFolderSearch('');
+                }}
+                onFocus={() => {
+                  combobox.openDropdown();
+                  setFolderSearch('');
+                }}
                 onBlur={() => {
                   combobox.closeDropdown();
-                  setFolderSearch(folderSearch || '');
+                  // Restore the selected folder path when closing
+                  if (ephemeral.folderId === null) {
+                    setFolderSearch('/ (Root)');
+                  } else {
+                    const selectedFolder = folderOptions.find((f) => f.id === ephemeral.folderId);
+                    setFolderSearch(selectedFolder?.path || '');
+                  }
                 }}
                 placeholder='Add to folder...'
                 rightSectionPointerEvents='none'
@@ -384,20 +359,11 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
             </Combobox.Target>
 
             <Combobox.Dropdown>
-              <Combobox.Options>
-                <Combobox.Option value='no folder'>No Folder</Combobox.Option>
-
-                {folderOptions
-                  .filter((f) => f.path.toLowerCase().includes(folderSearch.toLowerCase().trim()))
-                  .map((f) => (
-                    <Combobox.Option value={f.id} key={f.id}>
-                      <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
-                        {f.depth > 0 ? '└ ' : ''}
-                        {f.name}
-                      </Text>
-                    </Combobox.Option>
-                  ))}
-              </Combobox.Options>
+              <FolderComboboxOptions
+                folderOptions={folderOptions}
+                searchValue={folderSearch}
+                additionalOptions={<Combobox.Option value='__root__'>/ (Root)</Combobox.Option>}
+              />
             </Combobox.Dropdown>
           </Combobox>
 

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -30,11 +30,32 @@ import {
   IconTrashFilled,
   IconWriting,
 } from '@tabler/icons-react';
+
 import ms from 'ms';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 import { useShallow } from 'zustand/shallow';
+
+
+function checkDomains(domains?: unknown): string[] {
+  if (!domains) return [];
+  if (!Array.isArray(domains)) return [];
+
+  return domains;
+}
+
+function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
+  const parts: string[] = [];
+  let current: Folder | undefined = folder;
+
+  while (current) {
+    parts.unshift(current.name);
+    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
+  }
+
+  return parts.join(' / ');
+}
 
 export default function UploadOptionsButton({ folder, numFiles }: { folder?: string; numFiles: number }) {
   const config = useConfig();
@@ -66,6 +87,24 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
 
   const combobox = useCombobox();
   const [folderSearch, setFolderSearch] = useState('');
+
+
+
+  // Build folder options with full path for hierarchy display
+  const folderOptions = useMemo(() => {
+    if (!folders) return [];
+
+    const foldersMap = new Map(folders.map((f) => [f.id, f]));
+
+    return folders
+      .map((f) => ({
+        id: f.id,
+        name: f.name,
+        path: buildFolderPath(f, foldersMap),
+        depth: buildFolderPath(f, foldersMap).split(' / ').length - 1,
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }, [folders]);
 
   const expirations = useMemo(() => {
     const opts = [
@@ -300,7 +339,8 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
             store={combobox}
             withinPortal={false}
             onOptionSubmit={(value) => {
-              setFolderSearch(folders?.find((f) => f.id === value)?.name || '');
+              const selected = folderOptions.find((f) => f.id === value);
+              setFolderSearch(selected?.path || '');
               setEphemeral('folderId', value === 'no folder' || value === '' ? null : value);
               combobox.closeDropdown();
             }}
@@ -333,11 +373,14 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
               <Combobox.Options>
                 <Combobox.Option value='no folder'>No Folder</Combobox.Option>
 
-                {folders
-                  ?.filter((f) => f.name.toLowerCase().includes(folderSearch.toLowerCase().trim()))
+                {folderOptions
+                  .filter((f) => f.path.toLowerCase().includes(folderSearch.toLowerCase().trim()))
                   .map((f) => (
                     <Combobox.Option value={f.id} key={f.id}>
-                      {f.name}
+                      <Text size='sm' style={{ paddingLeft: f.depth * 12 }}>
+                        {f.depth > 0 ? '└ ' : ''}
+                        {f.name}
+                      </Text>
                     </Combobox.Option>
                   ))}
               </Combobox.Options>

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -45,29 +45,6 @@ function checkDomains(domains?: unknown): string[] {
   return domains;
 }
 
-function getFolderDepth(folder: Folder, foldersMap: Map<string, Folder>): number {
-  let depth = 0;
-  let current: Folder | undefined = folder.parentId ? foldersMap.get(folder.parentId) : undefined;
-
-  while (current) {
-    depth++;
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return depth;
-}
-
-function buildFolderPath(folder: Folder, foldersMap: Map<string, Folder>): string {
-  const parts: string[] = [];
-  let current: Folder | undefined = folder;
-
-  while (current) {
-    parts.unshift(current.name);
-    current = current.parentId ? foldersMap.get(current.parentId) : undefined;
-  }
-
-  return parts.join(' / ');
-}
 
 export default function UploadOptionsButton({ folder, numFiles }: { folder?: string; numFiles: number }) {
   const config = useConfig();
@@ -100,22 +77,48 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
   const combobox = useCombobox();
   const [folderSearch, setFolderSearch] = useState('');
 
-
-
-  // Build folder options with full path for hierarchy display
+  // Build folder options with hierarchy using depth-first traversal
   const folderOptions = useMemo(() => {
     if (!folders) return [];
 
-    const foldersMap = new Map(folders.map((f) => [f.id, f]));
+    // Group children by parent
+    const childrenMap = new Map<string | null, Folder[]>();
+    for (const folder of folders) {
+      const parentId = folder.parentId ?? null;
+      const siblings = childrenMap.get(parentId) || [];
+      siblings.push(folder);
+      childrenMap.set(parentId, siblings);
+    }
 
-    return folders
-      .map((f) => ({
-        id: f.id,
-        name: f.name,
-        path: buildFolderPath(f, foldersMap),
-        depth: getFolderDepth(f, foldersMap),
-      }))
-      .sort((a, b) => a.path.localeCompare(b.path));
+    // Sort children alphabetically within each level
+    for (const children of childrenMap.values()) {
+      children.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Depth-first traversal to build ordered list
+    const result: Array<{ id: string; name: string; path: string; depth: number }> = [];
+
+    const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
+      const currentPath = [...pathParts, folder.name];
+      result.push({
+        id: folder.id,
+        name: folder.name,
+        path: currentPath.join(' / '),
+        depth,
+      });
+
+      const children = childrenMap.get(folder.id) || [];
+      for (const child of children) {
+        traverse(child, depth + 1, currentPath);
+      }
+    };
+
+    const rootFolders = childrenMap.get(null) || [];
+    for (const root of rootFolders) {
+      traverse(root, 0, []);
+    }
+
+    return result;
   }, [folders]);
 
   const expirations = useMemo(() => {

--- a/src/lib/db/models/folder.ts
+++ b/src/lib/db/models/folder.ts
@@ -1,4 +1,5 @@
 import type { Folder as PrismaFolder } from '@/prisma/client';
+import { prisma } from '@/lib/db';
 import { File, cleanFiles } from './file';
 
 export type Folder = PrismaFolder & {
@@ -11,28 +12,79 @@ export type Folder = PrismaFolder & {
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function cleanFolder(folder: any, stringifyDates = false): any {
-  if (folder.files) cleanFiles(folder.files, stringifyDates);
+export interface FolderParent {
+  id: string;
+  name: string;
+  parentId: string | null;
+  parent?: FolderParent | null;
+}
 
-  if (folder.createdAt) folder.createdAt = stringifyDates ? folder.createdAt.toISOString() : folder.createdAt;
-  if (folder.updatedAt) folder.updatedAt = stringifyDates ? folder.updatedAt.toISOString() : folder.updatedAt;
+export interface FolderParentPublic extends FolderParent {
+  public: boolean;
+}
 
-  if (folder.children) {
+export async function buildParentChain(parentId: string | null): Promise<FolderParent | null> {
+  if (!parentId) return null;
+
+  const parent = await prisma.folder.findUnique({
+    where: { id: parentId },
+    select: { id: true, name: true, parentId: true },
+  });
+
+  if (!parent) return null;
+
+  const grandparent = await buildParentChain(parent.parentId);
+
+  return {
+    ...parent,
+    parent: grandparent,
+  };
+}
+
+export async function buildPublicParentChain(parentId: string | null): Promise<FolderParentPublic | null> {
+  if (!parentId) return null;
+
+  const parent = await prisma.folder.findUnique({
+    where: { id: parentId },
+    select: { id: true, name: true, public: true, parentId: true },
+  });
+
+  if (!parent || !parent.public) return null;
+
+  const grandparent = await buildPublicParentChain(parent.parentId);
+
+  return {
+    ...parent,
+    parent: grandparent,
+  };
+}
+
+export function cleanFolder<T extends Record<string, unknown>>(folder: T, stringifyDates = false): T {
+  if (folder.files && Array.isArray(folder.files)) cleanFiles(folder.files as any, stringifyDates);
+
+  if (folder.createdAt)
+    (folder.createdAt as unknown) = stringifyDates
+      ? (folder.createdAt as Date).toISOString()
+      : folder.createdAt;
+  if (folder.updatedAt)
+    (folder.updatedAt as unknown) = stringifyDates
+      ? (folder.updatedAt as Date).toISOString()
+      : folder.updatedAt;
+
+  if (folder.children && Array.isArray(folder.children)) {
     for (const child of folder.children) {
-      cleanFolder(child, stringifyDates);
+      cleanFolder(child as Record<string, unknown>, stringifyDates);
     }
   }
 
-  if (folder.parent) {
-    cleanFolder(folder.parent, stringifyDates);
+  if (folder.parent && typeof folder.parent === 'object') {
+    cleanFolder(folder.parent as Record<string, unknown>, stringifyDates);
   }
 
   return folder;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function cleanFolders(folders: any[], stringifyDates = false): any[] {
+export function cleanFolders<T extends Record<string, unknown>>(folders: T[], stringifyDates = false): T[] {
   for (let i = 0; i !== folders.length; ++i) {
     cleanFolder(folders[i], stringifyDates);
   }

--- a/src/lib/db/models/folder.ts
+++ b/src/lib/db/models/folder.ts
@@ -3,9 +3,15 @@ import { File, cleanFiles } from './file';
 
 export type Folder = PrismaFolder & {
   files?: File[];
+  parent?: Folder | null;
+  children?: Folder[];
+  _count?: {
+    children?: number;
+    files?: number;
+  };
 };
 
-export function cleanFolder(folder: Partial<Folder>, stringifyDates = false) {
+export function cleanFolder(folder: Partial<Folder>, stringifyDates = false): Partial<Folder> {
   if (folder.files) cleanFiles(folder.files, stringifyDates);
 
   if (folder.createdAt)
@@ -13,14 +19,22 @@ export function cleanFolder(folder: Partial<Folder>, stringifyDates = false) {
   if (folder.updatedAt)
     (folder as any).updatedAt = stringifyDates ? folder.updatedAt.toISOString() : folder.updatedAt;
 
+  if (folder.children) {
+    for (const child of folder.children) {
+      cleanFolder(child, stringifyDates);
+    }
+  }
+
+  if (folder.parent) {
+    cleanFolder(folder.parent, stringifyDates);
+  }
+
   return folder;
 }
 
-export function cleanFolders(folders: Folder[]) {
+export function cleanFolders(folders: Folder[], stringifyDates = false): Folder[] {
   for (let i = 0; i !== folders.length; ++i) {
-    const folder = folders[i];
-
-    if (folder.files) cleanFiles(folder.files);
+    cleanFolder(folders[i], stringifyDates);
   }
 
   return folders;

--- a/src/lib/db/models/folder.ts
+++ b/src/lib/db/models/folder.ts
@@ -15,10 +15,8 @@ export type Folder = PrismaFolder & {
 export function cleanFolder(folder: any, stringifyDates = false): any {
   if (folder.files) cleanFiles(folder.files, stringifyDates);
 
-  if (folder.createdAt)
-    folder.createdAt = stringifyDates ? folder.createdAt.toISOString() : folder.createdAt;
-  if (folder.updatedAt)
-    folder.updatedAt = stringifyDates ? folder.updatedAt.toISOString() : folder.updatedAt;
+  if (folder.createdAt) folder.createdAt = stringifyDates ? folder.createdAt.toISOString() : folder.createdAt;
+  if (folder.updatedAt) folder.updatedAt = stringifyDates ? folder.updatedAt.toISOString() : folder.updatedAt;
 
   if (folder.children) {
     for (const child of folder.children) {

--- a/src/lib/db/models/folder.ts
+++ b/src/lib/db/models/folder.ts
@@ -3,21 +3,22 @@ import { File, cleanFiles } from './file';
 
 export type Folder = PrismaFolder & {
   files?: File[];
-  parent?: Folder | null;
-  children?: Folder[];
+  parent?: Partial<PrismaFolder> | null;
+  children?: Partial<Folder>[];
   _count?: {
     children?: number;
     files?: number;
   };
 };
 
-export function cleanFolder(folder: Partial<Folder>, stringifyDates = false): Partial<Folder> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function cleanFolder(folder: any, stringifyDates = false): any {
   if (folder.files) cleanFiles(folder.files, stringifyDates);
 
   if (folder.createdAt)
-    (folder as any).createdAt = stringifyDates ? folder.createdAt.toISOString() : folder.createdAt;
+    folder.createdAt = stringifyDates ? folder.createdAt.toISOString() : folder.createdAt;
   if (folder.updatedAt)
-    (folder as any).updatedAt = stringifyDates ? folder.updatedAt.toISOString() : folder.updatedAt;
+    folder.updatedAt = stringifyDates ? folder.updatedAt.toISOString() : folder.updatedAt;
 
   if (folder.children) {
     for (const child of folder.children) {
@@ -32,7 +33,8 @@ export function cleanFolder(folder: Partial<Folder>, stringifyDates = false): Pa
   return folder;
 }
 
-export function cleanFolders(folders: Folder[], stringifyDates = false): Folder[] {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function cleanFolders(folders: any[], stringifyDates = false): any[] {
   for (let i = 0; i !== folders.length; ++i) {
     cleanFolder(folders[i], stringifyDates);
   }

--- a/src/lib/folderHierarchy.ts
+++ b/src/lib/folderHierarchy.ts
@@ -7,14 +7,6 @@ export interface FolderHierarchyItem {
   depth: number;
 }
 
-/**
- * Gets all descendant folder IDs for a given folder.
- * Recursively traverses the folder tree to find all children, grandchildren, etc.
- *
- * @param folderId - The ID of the parent folder
- * @param folders - Array of all folders
- * @returns Set of descendant folder IDs
- */
 export function getDescendantIds(folderId: string, folders: Folder[]): Set<string> {
   const descendants = new Set<string>();
   const addDescendants = (parentId: string) => {
@@ -29,19 +21,13 @@ export function getDescendantIds(folderId: string, folders: Folder[]): Set<strin
   return descendants;
 }
 
-/**
- * Builds a hierarchical, sorted list of folders with depth and path information.
- *
- * @param folders - Array of all folders
- * @param excludeIds - Optional set of folder IDs to exclude from the hierarchy
- * @returns Array of folder items with hierarchy information (id, name, path, depth)
- */
+
 export function buildFolderHierarchy(folders: Folder[], excludeIds?: Set<string>): FolderHierarchyItem[] {
-  // Group children by parent
+
   const childrenMap = new Map<string | null, Folder[]>();
 
   for (const folder of folders) {
-    // Skip excluded folders
+
     if (excludeIds?.has(folder.id)) continue;
 
     const parentId = folder.parentId ?? null;
@@ -50,12 +36,10 @@ export function buildFolderHierarchy(folders: Folder[], excludeIds?: Set<string>
     childrenMap.set(parentId, siblings);
   }
 
-  // Sort children alphabetically within each level
   for (const children of childrenMap.values()) {
     children.sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  // Depth-first traversal to build ordered list
   const result: FolderHierarchyItem[] = [];
 
   const traverse = (folder: Folder, depth: number, pathParts: string[]) => {

--- a/src/lib/folderHierarchy.ts
+++ b/src/lib/folderHierarchy.ts
@@ -1,0 +1,82 @@
+import { Folder } from './db/models/folder';
+
+export interface FolderHierarchyItem {
+  id: string;
+  name: string;
+  path: string;
+  depth: number;
+}
+
+/**
+ * Gets all descendant folder IDs for a given folder.
+ * Recursively traverses the folder tree to find all children, grandchildren, etc.
+ *
+ * @param folderId - The ID of the parent folder
+ * @param folders - Array of all folders
+ * @returns Set of descendant folder IDs
+ */
+export function getDescendantIds(folderId: string, folders: Folder[]): Set<string> {
+  const descendants = new Set<string>();
+  const addDescendants = (parentId: string) => {
+    for (const f of folders) {
+      if (f.parentId === parentId) {
+        descendants.add(f.id);
+        addDescendants(f.id);
+      }
+    }
+  };
+  addDescendants(folderId);
+  return descendants;
+}
+
+/**
+ * Builds a hierarchical, sorted list of folders with depth and path information.
+ *
+ * @param folders - Array of all folders
+ * @param excludeIds - Optional set of folder IDs to exclude from the hierarchy
+ * @returns Array of folder items with hierarchy information (id, name, path, depth)
+ */
+export function buildFolderHierarchy(folders: Folder[], excludeIds?: Set<string>): FolderHierarchyItem[] {
+  // Group children by parent
+  const childrenMap = new Map<string | null, Folder[]>();
+
+  for (const folder of folders) {
+    // Skip excluded folders
+    if (excludeIds?.has(folder.id)) continue;
+
+    const parentId = folder.parentId ?? null;
+    const siblings = childrenMap.get(parentId) || [];
+    siblings.push(folder);
+    childrenMap.set(parentId, siblings);
+  }
+
+  // Sort children alphabetically within each level
+  for (const children of childrenMap.values()) {
+    children.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  // Depth-first traversal to build ordered list
+  const result: FolderHierarchyItem[] = [];
+
+  const traverse = (folder: Folder, depth: number, pathParts: string[]) => {
+    const currentPath = [...pathParts, folder.name];
+    result.push({
+      id: folder.id,
+      name: folder.name,
+      path: currentPath.join(' / '),
+      depth,
+    });
+
+    const children = childrenMap.get(folder.id) || [];
+    for (const child of children) {
+      traverse(child, depth + 1, currentPath);
+    }
+  };
+
+  const rootFolders = childrenMap.get(null) || [];
+  for (const root of rootFolders) {
+    traverse(root, 0, []);
+  }
+
+  return result;
+}

--- a/src/lib/hooks/useFolders.ts
+++ b/src/lib/hooks/useFolders.ts
@@ -2,14 +2,6 @@ import { Response } from '@/lib/api/response';
 import { Folder } from '@/lib/db/models/folder';
 import useSWR from 'swr';
 
-/**
- * Custom hook to fetch folders with optional user parameter.
- * Uses the noincl=true parameter to fetch folders without file inclusions.
- *
- * @param user - Optional user ID to fetch folders for a specific user
- * @param enabled - Whether the fetch should be enabled (default: true)
- * @returns SWR response with folders data
- */
 export function useFolders(user?: string, enabled: boolean = true) {
   const key = enabled ? '/api/user/folders?noincl=true' + (user ? `&user=${user}` : '') : null;
 

--- a/src/lib/hooks/useFolders.ts
+++ b/src/lib/hooks/useFolders.ts
@@ -1,0 +1,17 @@
+import { Response } from '@/lib/api/response';
+import { Folder } from '@/lib/db/models/folder';
+import useSWR from 'swr';
+
+/**
+ * Custom hook to fetch folders with optional user parameter.
+ * Uses the noincl=true parameter to fetch folders without file inclusions.
+ *
+ * @param user - Optional user ID to fetch folders for a specific user
+ * @param enabled - Whether the fetch should be enabled (default: true)
+ * @returns SWR response with folders data
+ */
+export function useFolders(user?: string, enabled: boolean = true) {
+  const key = enabled ? '/api/user/folders?noincl=true' + (user ? `&user=${user}` : '') : null;
+
+  return useSWR<Extract<Response['/api/user/folders'], Folder[]>>(key);
+}

--- a/src/lib/import/version4/validateExport.ts
+++ b/src/lib/import/version4/validateExport.ts
@@ -139,6 +139,7 @@ export const export4Schema = z.object({
         allowUploads: z.boolean(),
         files: z.array(z.string()),
         userId: z.string(),
+        parentId: z.string().nullable().optional(),
       }),
     ),
     urls: z.array(

--- a/src/server/routes/api/server/export.ts
+++ b/src/server/routes/api/server/export.ts
@@ -194,6 +194,7 @@ export default typedPlugin(
               allowUploads: folder.allowUploads,
               userId: folder.userId,
               files: folder.files.map((file) => file.id),
+              parentId: folder.parentId,
             });
           }
 

--- a/src/server/routes/api/server/folder.ts
+++ b/src/server/routes/api/server/folder.ts
@@ -6,6 +6,27 @@ import z from 'zod';
 
 export type ApiServerFolderResponse = Partial<Folder>;
 
+// Recursively fetch public parent chain for breadcrumbs
+async function buildPublicParentChain(
+  parentId: string | null,
+): Promise<{ id: string; name: string; public: boolean; parentId: string | null; parent?: unknown } | null> {
+  if (!parentId) return null;
+
+  const parent = await prisma.folder.findUnique({
+    where: { id: parentId },
+    select: { id: true, name: true, public: true, parentId: true },
+  });
+
+  if (!parent || !parent.public) return null;
+
+  const grandparent = await buildPublicParentChain(parent.parentId);
+
+  return {
+    ...parent,
+    parent: grandparent,
+  };
+}
+
 export const PATH = '/api/server/folder/:id';
 export default typedPlugin(
   async (server) => {
@@ -63,6 +84,11 @@ export default typedPlugin(
         if (!folder) return res.notFound();
 
         if ((uploads && !folder.allowUploads) || (!uploads && !folder.public)) return res.notFound();
+
+        // Build full public parent chain for breadcrumbs
+        if (folder.parentId) {
+          (folder as any).parent = await buildPublicParentChain(folder.parentId);
+        }
 
         return res.send(cleanFolder(folder, true));
       },

--- a/src/server/routes/api/server/folder.ts
+++ b/src/server/routes/api/server/folder.ts
@@ -1,31 +1,10 @@
 import { prisma } from '@/lib/db';
 import { fileSelect } from '@/lib/db/models/file';
-import { cleanFolder, Folder } from '@/lib/db/models/folder';
+import { buildPublicParentChain, cleanFolder, Folder } from '@/lib/db/models/folder';
 import typedPlugin from '@/server/typedPlugin';
 import z from 'zod';
 
 export type ApiServerFolderResponse = Partial<Folder>;
-
-// Recursively fetch public parent chain for breadcrumbs
-async function buildPublicParentChain(
-  parentId: string | null,
-): Promise<{ id: string; name: string; public: boolean; parentId: string | null; parent?: unknown } | null> {
-  if (!parentId) return null;
-
-  const parent = await prisma.folder.findUnique({
-    where: { id: parentId },
-    select: { id: true, name: true, public: true, parentId: true },
-  });
-
-  if (!parent || !parent.public) return null;
-
-  const grandparent = await buildPublicParentChain(parent.parentId);
-
-  return {
-    ...parent,
-    parent: grandparent,
-  };
-}
 
 export const PATH = '/api/server/folder/:id';
 export default typedPlugin(
@@ -85,7 +64,6 @@ export default typedPlugin(
 
         if ((uploads && !folder.allowUploads) || (!uploads && !folder.public)) return res.notFound();
 
-        // Build full public parent chain for breadcrumbs
         if (folder.parentId) {
           (folder as any).parent = await buildPublicParentChain(folder.parentId);
         }

--- a/src/server/routes/api/server/folder.ts
+++ b/src/server/routes/api/server/folder.ts
@@ -40,6 +40,23 @@ export default typedPlugin(
                 createdAt: 'desc',
               },
             },
+            children: {
+              where: { public: true },
+              orderBy: { createdAt: 'desc' },
+              select: {
+                id: true,
+                name: true,
+                createdAt: true,
+                updatedAt: true,
+                public: true,
+                _count: {
+                  select: { children: true, files: true },
+                },
+              },
+            },
+            parent: {
+              select: { id: true, name: true, public: true, parentId: true },
+            },
           },
         });
 

--- a/src/server/routes/api/server/import/v4.ts
+++ b/src/server/routes/api/server/import/v4.ts
@@ -247,8 +247,9 @@ export default typedPlugin(
 
         logger.debug('imported passkeys', { passkeys: importedPasskeys });
 
-        // folders
+        // folders - first pass: create all folders without parent relationships
         const importedFolders: Record<string, string> = {};
+        const folderParentMap: Record<string, string> = {};
 
         for (const folder of export4.data.folders) {
           const userId = importedUsers[folder.userId ?? ''];
@@ -288,7 +289,31 @@ export default typedPlugin(
           });
 
           importedFolders[folder.id] = created.id;
+
+          if (folder.parentId) {
+            folderParentMap[folder.id] = folder.parentId;
+          }
         }
+
+        // folders - second pass: set parent relationships
+        for (const [oldFolderId, oldParentId] of Object.entries(folderParentMap)) {
+          const newFolderId = importedFolders[oldFolderId];
+          const newParentId = importedFolders[oldParentId];
+
+          if (newFolderId && newParentId) {
+            await prisma.folder.update({
+              where: { id: newFolderId },
+              data: { parentId: newParentId },
+            });
+          } else {
+            logger.warn('failed to set parent for folder', {
+              folder: oldFolderId,
+              parent: oldParentId,
+            });
+          }
+        }
+
+        logger.debug('imported folders', { folders: importedFolders });
 
         // files
         const importedFiles: Record<string, string> = {};

--- a/src/server/routes/api/user/folders/[id]/export.ts
+++ b/src/server/routes/api/user/folders/[id]/export.ts
@@ -36,6 +36,9 @@ export default typedPlugin(
 
         res.hijack();
 
+        res.raw.setHeader('Content-Type', 'application/zip');
+        res.raw.setHeader('Content-Disposition', `attachment; filename="${folder.name}.zip"`);
+
         const zip = archiver('zip', {
           zlib: { level: 9 },
         });

--- a/src/server/routes/api/user/folders/[id]/export.ts
+++ b/src/server/routes/api/user/folders/[id]/export.ts
@@ -17,7 +17,6 @@ type FolderWithFilesAndChildren = {
   children: FolderWithFilesAndChildren[];
 };
 
-// Recursively fetch folder with all descendants
 async function getFolderTree(folderId: string, userId: string): Promise<FolderWithFilesAndChildren | null> {
   const folder = await prisma.folder.findUnique({
     where: { id: folderId, userId },
@@ -45,7 +44,6 @@ async function getFolderTree(folderId: string, userId: string): Promise<FolderWi
   };
 }
 
-// Recursively add files to zip with proper paths
 async function addFolderToZip(
   zip: Archiver,
   folder: FolderWithFilesAndChildren,
@@ -91,7 +89,6 @@ export default typedPlugin(
         if (!folder) return res.notFound('Folder not found');
         if (req.user.id !== folder.userId) return res.forbidden('You do not own this folder');
 
-        // Get full folder tree with all descendants
         const folderTree = await getFolderTree(id, req.user.id);
         if (!folderTree) return res.notFound('Folder not found');
 

--- a/src/server/routes/api/user/folders/[id]/export.ts
+++ b/src/server/routes/api/user/folders/[id]/export.ts
@@ -3,12 +3,76 @@ import { prisma } from '@/lib/db';
 import { log } from '@/lib/logger';
 import { userMiddleware } from '@/server/middleware/user';
 import typedPlugin from '@/server/typedPlugin';
-import archiver from 'archiver';
+import archiver, { Archiver } from 'archiver';
 import z from 'zod';
 
 export type ApiUserFoldersIdExportResponse = null;
 
 const logger = log('api').c('user').c('folders').c('[id]').c('export');
+
+type FolderWithFilesAndChildren = {
+  id: string;
+  name: string;
+  files: { id: string; name: string }[];
+  children: FolderWithFilesAndChildren[];
+};
+
+// Recursively fetch folder with all descendants
+async function getFolderTree(folderId: string, userId: string): Promise<FolderWithFilesAndChildren | null> {
+  const folder = await prisma.folder.findUnique({
+    where: { id: folderId, userId },
+    select: {
+      id: true,
+      name: true,
+      files: { select: { id: true, name: true } },
+      children: { select: { id: true } },
+    },
+  });
+
+  if (!folder) return null;
+
+  const children: FolderWithFilesAndChildren[] = [];
+  for (const child of folder.children) {
+    const childTree = await getFolderTree(child.id, userId);
+    if (childTree) children.push(childTree);
+  }
+
+  return {
+    id: folder.id,
+    name: folder.name,
+    files: folder.files,
+    children,
+  };
+}
+
+// Recursively add files to zip with proper paths
+async function addFolderToZip(
+  zip: Archiver,
+  folder: FolderWithFilesAndChildren,
+  basePath: string,
+  logger: ReturnType<typeof log>,
+): Promise<number> {
+  let fileCount = 0;
+
+  for (const file of folder.files) {
+    const stream = await datasource.get(file.name);
+    if (!stream) {
+      logger.warn('failed to get file stream for folder export', { file: file.id, folder: folder.id });
+      continue;
+    }
+
+    const filePath = basePath ? `${basePath}/${file.name}` : file.name;
+    zip.append(stream, { name: filePath });
+    fileCount++;
+  }
+
+  for (const child of folder.children) {
+    const childPath = basePath ? `${basePath}/${child.name}` : child.name;
+    fileCount += await addFolderToZip(zip, child, childPath, logger);
+  }
+
+  return fileCount;
+}
 
 export const PATH = '/api/user/folders/:id/export';
 export default typedPlugin(
@@ -20,17 +84,16 @@ export default typedPlugin(
         const { id } = req.params;
 
         const folder = await prisma.folder.findUnique({
-          where: {
-            id,
-          },
-          include: {
-            files: true,
-          },
+          where: { id },
+          select: { id: true, name: true, userId: true },
         });
+
         if (!folder) return res.notFound('Folder not found');
         if (req.user.id !== folder.userId) return res.forbidden('You do not own this folder');
 
-        if (!folder.files.length) return res.badRequest("Can't export an empty folder.");
+        // Get full folder tree with all descendants
+        const folderTree = await getFolderTree(id, req.user.id);
+        if (!folderTree) return res.notFound('Folder not found');
 
         logger.info(`folder export requested: ${folder.name}`, { user: req.user.id, folder: folder.id });
 
@@ -45,14 +108,10 @@ export default typedPlugin(
 
         zip.pipe(res.raw);
 
-        for (const file of folder.files) {
-          const stream = await datasource.get(file.name);
-          if (!stream) {
-            logger.warn('failed to get file stream for folder export', { file: file.id, folder: folder.id });
-            continue;
-          }
+        const fileCount = await addFolderToZip(zip, folderTree, '', logger);
 
-          zip.append(stream, { name: file.name });
+        if (fileCount === 0) {
+          logger.warn('folder export has no files', { folder: folder.id });
         }
 
         zip.on('error', (err) => {
@@ -60,7 +119,11 @@ export default typedPlugin(
         });
 
         zip.on('finish', () => {
-          logger.info(`folder export completed: ${folder.name}`, { user: req.user.id, folder: folder.id });
+          logger.info(`folder export completed: ${folder.name}`, {
+            user: req.user.id,
+            folder: folder.id,
+            files: fileCount,
+          });
         });
 
         await zip.finalize();

--- a/src/server/routes/api/user/folders/[id]/index.ts
+++ b/src/server/routes/api/user/folders/[id]/index.ts
@@ -60,6 +60,20 @@ export default typedPlugin(
             },
           },
           User: true,
+          children: {
+            orderBy: { createdAt: 'desc' },
+            include: {
+              _count: {
+                select: { children: true, files: true },
+              },
+            },
+          },
+          parent: {
+            select: { id: true, name: true, parentId: true },
+          },
+          _count: {
+            select: { children: true, files: true },
+          },
         },
       });
       if (!folder) return res.notFound('Folder not found');
@@ -143,6 +157,7 @@ export default typedPlugin(
             isPublic: z.boolean().optional(),
             name: z.string().min(1).optional(),
             allowUploads: z.boolean().optional(),
+            parentId: z.string().nullable().optional(),
           }),
           params: paramsSchema,
         },
@@ -150,7 +165,39 @@ export default typedPlugin(
       },
       async (req, res) => {
         const { id: folderId } = req.params;
-        const { isPublic, name, allowUploads } = req.body;
+        const { isPublic, name, allowUploads, parentId } = req.body;
+
+        // Handle parentId change (moving folder)
+        if (parentId !== undefined) {
+          // Can't make a folder its own parent
+          if (parentId === folderId) {
+            return res.badRequest('A folder cannot be its own parent');
+          }
+
+          if (parentId !== null) {
+            // Verify new parent exists and belongs to user
+            const newParent = await prisma.folder.findUnique({
+              where: { id: parentId },
+              select: { id: true, userId: true, parentId: true },
+            });
+
+            if (!newParent) return res.notFound('Parent folder not found');
+            if (newParent.userId !== req.user.id) return res.forbidden('Parent folder does not belong to you');
+
+            // Check for circular reference - walk up the tree from new parent
+            let currentParentId: string | null = newParent.parentId;
+            while (currentParentId) {
+              if (currentParentId === folderId) {
+                return res.badRequest('Cannot move folder into one of its descendants');
+              }
+              const parent = await prisma.folder.findUnique({
+                where: { id: currentParentId },
+                select: { parentId: true },
+              });
+              currentParentId = parent?.parentId ?? null;
+            }
+          }
+        }
 
         const nFolder = await prisma.folder.update({
           where: {
@@ -160,6 +207,7 @@ export default typedPlugin(
             ...(isPublic !== undefined && { public: isPublic }),
             ...(name && { name }),
             ...(allowUploads !== undefined && { allowUploads }),
+            ...(parentId !== undefined && { parentId }),
           },
           include: {
             files: {
@@ -167,6 +215,12 @@ export default typedPlugin(
                 ...fileSelect,
                 password: true,
               },
+            },
+            _count: {
+              select: { children: true, files: true },
+            },
+            parent: {
+              select: { id: true, name: true, parentId: true },
             },
           },
         });
@@ -176,6 +230,7 @@ export default typedPlugin(
           isPublic,
           name,
           allowUploads,
+          parentId,
         });
 
         return res.send(cleanFolder(nFolder));

--- a/src/server/routes/api/user/folders/[id]/index.ts
+++ b/src/server/routes/api/user/folders/[id]/index.ts
@@ -23,6 +23,27 @@ function checkInteraction(current?: Partial<User> | null, owner?: Partial<User> 
 
 const logger = log('api').c('user').c('folders').c('[id]');
 
+// Recursively fetch and build the full parent chain
+async function buildParentChain(
+  parentId: string | null,
+): Promise<{ id: string; name: string; parentId: string | null } | null> {
+  if (!parentId) return null;
+
+  const parent = await prisma.folder.findUnique({
+    where: { id: parentId },
+    select: { id: true, name: true, parentId: true },
+  });
+
+  if (!parent) return null;
+
+  const grandparent = await buildParentChain(parent.parentId);
+
+  return {
+    ...parent,
+    parent: grandparent,
+  } as { id: string; name: string; parentId: string | null };
+}
+
 const paramsSchema = z.object({
   id: z.string(),
 });
@@ -78,6 +99,11 @@ export default typedPlugin(
       });
       if (!folder) return res.notFound('Folder not found');
       if (!checkInteraction(req.user, folder.User)) return res.notFound('Folder not found');
+
+      // Build full parent chain for breadcrumbs
+      if (folder.parentId) {
+        (folder as any).parent = await buildParentChain(folder.parentId);
+      }
 
       return res.send(cleanFolder(folder));
     });

--- a/src/server/routes/api/user/folders/[id]/index.ts
+++ b/src/server/routes/api/user/folders/[id]/index.ts
@@ -182,7 +182,8 @@ export default typedPlugin(
             });
 
             if (!newParent) return res.notFound('Parent folder not found');
-            if (newParent.userId !== req.user.id) return res.forbidden('Parent folder does not belong to you');
+            if (newParent.userId !== req.user.id)
+              return res.forbidden('Parent folder does not belong to you');
 
             // Check for circular reference - walk up the tree from new parent
             let currentParentId: string | null = newParent.parentId;

--- a/src/server/routes/api/user/folders/[id]/index.ts
+++ b/src/server/routes/api/user/folders/[id]/index.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/db';
 import { fileSelect } from '@/lib/db/models/file';
-import { Folder, cleanFolder } from '@/lib/db/models/folder';
+import { buildParentChain, Folder, cleanFolder } from '@/lib/db/models/folder';
 import { User } from '@/lib/db/models/user';
 import { log } from '@/lib/logger';
 import { canInteract } from '@/lib/role';
@@ -22,27 +22,6 @@ function checkInteraction(current?: Partial<User> | null, owner?: Partial<User> 
 }
 
 const logger = log('api').c('user').c('folders').c('[id]');
-
-// Recursively fetch and build the full parent chain
-async function buildParentChain(
-  parentId: string | null,
-): Promise<{ id: string; name: string; parentId: string | null } | null> {
-  if (!parentId) return null;
-
-  const parent = await prisma.folder.findUnique({
-    where: { id: parentId },
-    select: { id: true, name: true, parentId: true },
-  });
-
-  if (!parent) return null;
-
-  const grandparent = await buildParentChain(parent.parentId);
-
-  return {
-    ...parent,
-    parent: grandparent,
-  } as { id: string; name: string; parentId: string | null };
-}
 
 const paramsSchema = z.object({
   id: z.string(),
@@ -100,7 +79,6 @@ export default typedPlugin(
       if (!folder) return res.notFound('Folder not found');
       if (!checkInteraction(req.user, folder.User)) return res.notFound('Folder not found');
 
-      // Build full parent chain for breadcrumbs
       if (folder.parentId) {
         (folder as any).parent = await buildParentChain(folder.parentId);
       }
@@ -193,15 +171,12 @@ export default typedPlugin(
         const { id: folderId } = req.params;
         const { isPublic, name, allowUploads, parentId } = req.body;
 
-        // Handle parentId change (moving folder)
         if (parentId !== undefined) {
-          // Can't make a folder its own parent
           if (parentId === folderId) {
             return res.badRequest('A folder cannot be its own parent');
           }
 
           if (parentId !== null) {
-            // Verify new parent exists and belongs to user
             const newParent = await prisma.folder.findUnique({
               where: { id: parentId },
               select: { id: true, userId: true, parentId: true },
@@ -271,6 +246,8 @@ export default typedPlugin(
           body: z.object({
             delete: z.enum(['file', 'folder']),
             id: z.string().min(1).optional(),
+            childrenAction: z.enum(['moveToRoot', 'moveToFolder', 'cascade']).optional(),
+            targetFolderId: z.string().optional(),
           }),
           params: paramsSchema,
         },
@@ -278,29 +255,79 @@ export default typedPlugin(
       },
       async (req, res) => {
         const { id: folderId } = req.params;
-        const { delete: del } = req.body;
+        const { delete: del, childrenAction, targetFolderId } = req.body;
 
         if (del === 'folder') {
-          const nFolder = await prisma.folder.delete({
-            where: {
-              id: folderId,
-            },
-            include: {
-              files: {
-                select: {
-                  ...fileSelect,
-                  password: true,
-                },
+          if (childrenAction === 'moveToFolder' && targetFolderId) {
+            const targetFolder = await prisma.folder.findUnique({
+              where: { id: targetFolderId },
+              select: { id: true, userId: true },
+            });
+            if (!targetFolder) return res.notFound('Target folder not found');
+            if (targetFolder.userId !== req.user.id)
+              return res.forbidden('Target folder does not belong to you');
+          }
+
+          if (childrenAction === 'moveToRoot') {
+            await prisma.folder.updateMany({
+              where: { parentId: folderId },
+              data: { parentId: null },
+            });
+            await prisma.file.updateMany({
+              where: { folderId: folderId },
+              data: { folderId: null },
+            });
+          } else if (childrenAction === 'moveToFolder' && targetFolderId) {
+            await prisma.folder.updateMany({
+              where: { parentId: folderId },
+              data: { parentId: targetFolderId },
+            });
+            await prisma.file.updateMany({
+              where: { folderId: folderId },
+              data: { folderId: targetFolderId },
+            });
+          } else if (childrenAction === 'cascade') {
+            const deleteRecursive = async (id: string) => {
+              const children = await prisma.folder.findMany({
+                where: { parentId: id },
+                select: { id: true },
+              });
+              for (const child of children) {
+                await deleteRecursive(child.id);
+              }
+              await prisma.folder.delete({ where: { id } });
+            };
+            await deleteRecursive(folderId);
+          }
+
+          if (!childrenAction || childrenAction !== 'cascade') {
+            const nFolder = await prisma.folder.delete({
+              where: {
+                id: folderId,
               },
-              User: true,
-            },
-          });
+              include: {
+                files: {
+                  select: {
+                    ...fileSelect,
+                    password: true,
+                  },
+                },
+                User: true,
+              },
+            });
 
-          logger.info('folder deleted', {
-            folder: nFolder.id,
-          });
+            logger.info('folder deleted', {
+              folder: nFolder.id,
+              childrenAction: childrenAction || 'default',
+            });
 
-          return res.send(cleanFolder(nFolder));
+            return res.send(cleanFolder(nFolder));
+          } else {
+            logger.info('folder cascade deleted', {
+              folder: folderId,
+            });
+            return res.send({ success: true });
+          }
         } else if (del === 'file') {
           const { id } = req.body;
           if (!id) return res.badRequest('File id is required');

--- a/src/server/routes/api/user/folders/index.ts
+++ b/src/server/routes/api/user/folders/index.ts
@@ -23,12 +23,14 @@ export default typedPlugin(
           querystring: z.object({
             noincl: zQsBoolean.optional(),
             user: z.string().optional(),
+            parentId: z.string().optional(),
+            root: z.string().optional(),
           }),
         },
         preHandler: [userMiddleware],
       },
       async (req, res) => {
-        const { noincl, user } = req.query;
+        const { noincl, user, parentId, root } = req.query;
 
         if (user) {
           const user = await prisma.user.findUnique({
@@ -46,12 +48,14 @@ export default typedPlugin(
         const folders = await prisma.folder.findMany({
           where: {
             userId: user || req.user.id,
+            ...(root !== undefined && { parentId: null }),
+            ...(parentId && { parentId }),
           },
           orderBy: {
             createdAt: 'desc',
           },
-          ...(!noincl && {
-            include: {
+          include: {
+            ...(!noincl && {
               files: {
                 select: {
                   ...fileSelect,
@@ -61,8 +65,21 @@ export default typedPlugin(
                   createdAt: 'desc',
                 },
               },
+            }),
+            _count: {
+              select: {
+                children: true,
+                files: true,
+              },
             },
-          }),
+            parent: {
+              select: {
+                id: true,
+                name: true,
+                parentId: true,
+              },
+            },
+          },
         });
 
         return res.send(cleanFolders(folders));
@@ -77,14 +94,25 @@ export default typedPlugin(
             name: z.string().trim().min(1),
             isPublic: z.boolean().optional(),
             files: z.array(z.string()).optional(),
+            parentId: z.string().optional(),
           }),
         },
         preHandler: [userMiddleware],
         ...secondlyRatelimit(2),
       },
       async (req, res) => {
-        const { name, isPublic } = req.body;
+        const { name, isPublic, parentId } = req.body;
         let files = req.body.files;
+
+        if (parentId) {
+          const parentFolder = await prisma.folder.findUnique({
+            where: { id: parentId },
+            select: { id: true, userId: true },
+          });
+
+          if (!parentFolder) return res.notFound('Parent folder not found');
+          if (parentFolder.userId !== req.user.id) return res.forbidden('Parent folder does not belong to you');
+        }
 
         if (files) {
           const filesAdd = await prisma.file.findMany({
@@ -107,6 +135,7 @@ export default typedPlugin(
           data: {
             name,
             userId: req.user.id,
+            ...(parentId && { parentId }),
             ...(files?.length && {
               files: {
                 connect: files!.map((f) => ({ id: f })),
@@ -121,6 +150,19 @@ export default typedPlugin(
                 password: true,
               },
             },
+            _count: {
+              select: {
+                children: true,
+                files: true,
+              },
+            },
+            parent: {
+              select: {
+                id: true,
+                name: true,
+                parentId: true,
+              },
+            },
           },
         });
 
@@ -128,6 +170,7 @@ export default typedPlugin(
           folder: folder.name,
           user: req.user.username,
           files: files?.length || undefined,
+          parentId: parentId || undefined,
         });
 
         return res.send(cleanFolder(folder));

--- a/src/server/routes/api/user/folders/index.ts
+++ b/src/server/routes/api/user/folders/index.ts
@@ -111,7 +111,8 @@ export default typedPlugin(
           });
 
           if (!parentFolder) return res.notFound('Parent folder not found');
-          if (parentFolder.userId !== req.user.id) return res.forbidden('Parent folder does not belong to you');
+          if (parentFolder.userId !== req.user.id)
+            return res.forbidden('Parent folder does not belong to you');
         }
 
         if (files) {


### PR DESCRIPTION
## Add Nested Folders Support

This PR implements the ability to nest folders within other folders, creating a hierarchical folder structure.

### Database Changes

- Added `parentId` field to `Folder` model with self-referential relation
- `onDelete: SetNull` ensures orphaned folders move to root when parent is deleted

### Backend API

- **GET `/api/user/folders`**: Added `parentId` and `root` query params for filtering by hierarchy level
- **POST `/api/user/folders`**: Accepts optional `parentId` to create subfolders
- **PATCH `/api/user/folders/[id]`**: Accepts `parentId` to move folders, with circular reference validation
- **GET `/api/server/folder/:id`**: Returns public children and full parent chain for breadcrumb navigation
- All folder responses now include `_count.children`, `_count.files`, and `parent` data

### Frontend UI

- **Dashboard Folders**: Click folders to navigate into them, breadcrumb navigation to go back

<img width="1123" height="282" alt="grafik" src="https://github.com/user-attachments/assets/9b5f4ea4-632e-43a9-8425-d62bce030315" />

- **Create Folder**: When inside a folder, creates a subfolder
<img width="446" height="241" alt="grafik" src="https://github.com/user-attachments/assets/29f1f22e-caae-4062-b547-91f91d5f5fca" />

- **Move Folder**: New modal to move folders to different parents or root
<img width="433" height="396" alt="grafik" src="https://github.com/user-attachments/assets/529e5b34-0db1-4848-a0e0-7b6997a61384" />

- **Folder Dropdowns**: All "Add to folder" dropdowns now display folder hierarchy using tree visualization with proper indentation
<img width="554" height="394" alt="grafik" src="https://github.com/user-attachments/assets/f9290187-850d-4322-a219-b6ef5fc49dd9" />

- **Public Folder View**: Shows subfolders with breadcrumb navigation for public parent chain
<img width="627" height="339" alt="grafik" src="https://github.com/user-attachments/assets/aebe128a-c638-43d2-85f8-0a5a5f90e13e" />

### Import/Export

- Export includes hierarchy for folders
- Import uses two-pass approach: create folders first, then set parent relationships

### Breaking Changes

None. All API changes are additive and backwards compatible.

