### PR TITLE
fix: missing input field names

### DIFF
--- a/src/client/pages/auth/login.tsx
+++ b/src/client/pages/auth/login.tsx
@@ -86,6 +86,9 @@ export default function Login() {
       username: (value) => (value.length > 1 ? null : 'Username is required'),
       password: (value) => (value.length > 1 ? null : 'Password is required'),
     },
+    enhanceGetInputProps: ({ field }) => ({
+      name: field,
+    }),
   });
 
   const onSubmit = async (values: typeof form.values, code: string | undefined = undefined) => {
@@ -312,9 +315,9 @@ export default function Login() {
             <form onSubmit={form.onSubmit((v) => onSubmit(v))}>
               <Stack my='sm'>
                 <TextInput
-                  name='username'
                   size='md'
                   placeholder='Enter your username...'
+                  autoComplete='username'
                   styles={{
                     input: {
                       backgroundColor: config.website.loginBackground ? 'transparent' : undefined,
@@ -324,9 +327,9 @@ export default function Login() {
                 />
 
                 <PasswordInput
-                  name='password'
                   size='md'
                   placeholder='Enter your password...'
+                  autoComplete='current-password'
                   styles={{
                     input: {
                       backgroundColor: config.website.loginBackground ? 'transparent' : undefined,

--- a/src/client/pages/auth/login.tsx
+++ b/src/client/pages/auth/login.tsx
@@ -312,6 +312,7 @@ export default function Login() {
             <form onSubmit={form.onSubmit((v) => onSubmit(v))}>
               <Stack my='sm'>
                 <TextInput
+                  name='username'
                   size='md'
                   placeholder='Enter your username...'
                   styles={{
@@ -323,6 +324,7 @@ export default function Login() {
                 />
 
                 <PasswordInput
+                  name='password'
                   size='md'
                   placeholder='Enter your password...'
                   styles={{

--- a/src/client/pages/auth/register.tsx
+++ b/src/client/pages/auth/register.tsx
@@ -67,6 +67,9 @@ export function Component() {
       username: (value) => (value.length < 1 ? 'Username is required' : null),
       password: (value) => (value.length < 1 ? 'Password is required' : null),
     },
+    enhanceGetInputProps: ({ field }) => ({
+      name: field,
+    }),
   });
 
   useEffect(() => {
@@ -212,9 +215,9 @@ export function Component() {
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack my='sm'>
             <TextInput
-              name='username'
               size='md'
               placeholder='Enter your username...'
+              autoComplete='username'
               styles={{
                 input: {
                   backgroundColor: config.website.loginBackground ? 'transparent' : undefined,
@@ -224,9 +227,9 @@ export function Component() {
             />
 
             <PasswordInput
-              name='password'
               size='md'
               placeholder='Enter your password...'
+              autoComplete='new-password'
               styles={{
                 input: {
                   backgroundColor: config.website.loginBackground ? 'transparent' : undefined,

--- a/src/client/pages/auth/register.tsx
+++ b/src/client/pages/auth/register.tsx
@@ -212,6 +212,7 @@ export function Component() {
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack my='sm'>
             <TextInput
+              name='username'
               size='md'
               placeholder='Enter your username...'
               styles={{
@@ -223,6 +224,7 @@ export function Component() {
             />
 
             <PasswordInput
+              name='password'
               size='md'
               placeholder='Enter your password...'
               styles={{

--- a/src/client/pages/auth/setup.tsx
+++ b/src/client/pages/auth/setup.tsx
@@ -65,6 +65,9 @@ export function Component() {
       username: (value) => (value.length < 1 ? 'Username is required' : null),
       password: (value) => (value.length < 1 ? 'Password is required' : null),
     },
+    enhanceGetInputProps: ({ field }) => ({
+      name: field,
+    }),
   });
 
   const onSubmit = async (values: typeof form.values) => {
@@ -178,16 +181,16 @@ export function Component() {
               <Title order={2}>Create your super-admin account</Title>
 
               <TextInput
-                name='username'
                 label='Username'
                 placeholder='Enter a username...'
+                autoComplete='username'
                 {...form.getInputProps('username')}
               />
 
               <PasswordInput
-                name='password'
                 label='Password'
                 placeholder='Enter a password...'
+                autoComplete='new-password'
                 {...form.getInputProps('password')}
               />
             </Stack>

--- a/src/client/pages/auth/setup.tsx
+++ b/src/client/pages/auth/setup.tsx
@@ -178,12 +178,14 @@ export function Component() {
               <Title order={2}>Create your super-admin account</Title>
 
               <TextInput
+                name='username'
                 label='Username'
                 placeholder='Enter a username...'
                 {...form.getInputProps('username')}
               />
 
               <PasswordInput
+                name='password'
                 label='Password'
                 placeholder='Enter a password...'
                 {...form.getInputProps('password')}

--- a/src/components/pages/users/EditUserModal.tsx
+++ b/src/components/pages/users/EditUserModal.tsx
@@ -163,11 +163,13 @@ export default function EditUserModal({
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack gap='sm'>
             <TextInput
+              name='username'
               label='Username'
               placeholder='Enter a username...'
               {...form.getInputProps('username')}
             />
             <PasswordInput
+              name='password'
               label='Password'
               placeholder='Enter a password...'
               autoComplete='new-password'

--- a/src/components/pages/users/EditUserModal.tsx
+++ b/src/components/pages/users/EditUserModal.tsx
@@ -69,6 +69,9 @@ export default function EditUserModal({
         if (typeof value !== 'number' || value < 0) return 'Invalid value';
       },
     },
+    enhanceGetInputProps: ({ field }) => ({
+      name: field,
+    }),
   });
 
   const onSubmit = async (values: typeof form.values) => {
@@ -163,13 +166,12 @@ export default function EditUserModal({
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack gap='sm'>
             <TextInput
-              name='username'
               label='Username'
               placeholder='Enter a username...'
+              autoComplete='username'
               {...form.getInputProps('username')}
             />
             <PasswordInput
-              name='password'
               label='Password'
               placeholder='Enter a password...'
               autoComplete='new-password'

--- a/src/components/pages/users/index.tsx
+++ b/src/components/pages/users/index.tsx
@@ -99,11 +99,13 @@ export default function DashboardUsers() {
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack gap='sm'>
             <TextInput
+              name='username'
               label='Username'
               placeholder='Enter a username...'
               {...form.getInputProps('username')}
             />
             <PasswordInput
+              name='password'
               label='Password'
               placeholder='Enter a password...'
               autoComplete='new-password'

--- a/src/components/pages/users/index.tsx
+++ b/src/components/pages/users/index.tsx
@@ -48,6 +48,9 @@ export default function DashboardUsers() {
       username: (value) => (value.length < 1 ? 'Username is required' : null),
       password: (value) => (value.length < 1 ? 'Password is required' : null),
     },
+    enhanceGetInputProps: ({ field }) => ({
+      name: field,
+    }),
   });
 
   const onSubmit = async (values: typeof form.values) => {
@@ -99,13 +102,12 @@ export default function DashboardUsers() {
         <form onSubmit={form.onSubmit(onSubmit)}>
           <Stack gap='sm'>
             <TextInput
-              name='username'
               label='Username'
               placeholder='Enter a username...'
+              autoComplete='username'
               {...form.getInputProps('username')}
             />
             <PasswordInput
-              name='password'
               label='Password'
               placeholder='Enter a password...'
               autoComplete='new-password'


### PR DESCRIPTION
Specifying `name` attributes on the username and password text fields allows password managers to reliably identify them when autofilling.