### PR TITLE
feat: custom filename format

### DIFF
--- a/prisma/migrations/20260324202144_custom_file_format/migration.sql
+++ b/prisma/migrations/20260324202144_custom_file_format/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Zipline" ADD COLUMN     "filesCustomFormat" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Zipline {
   filesRoute                    String   @default("/u")
   filesLength                   Int      @default(6)
   filesDefaultFormat            String   @default("random")
+  filesCustomFormat             String?
   filesDisabledExtensions       String[]
   filesMaxFileSize              String   @default("100mb")
   filesDefaultExpiration        String?

--- a/src/components/pages/serverSettings/parts/Files.tsx
+++ b/src/components/pages/serverSettings/parts/Files.tsx
@@ -17,6 +17,7 @@ export default function Files({
     filesRoute: string;
     filesLength: number;
     filesDefaultFormat: string;
+    filesCustomFormat: string | null;
     filesDisabledExtensions: string;
     filesMaxFileSize: string;
     filesDefaultExpiration: string | null;
@@ -33,6 +34,7 @@ export default function Files({
       filesRoute: '/u',
       filesLength: 6,
       filesDefaultFormat: 'random',
+      filesCustomFormat: '',
       filesDisabledExtensions: '',
       filesMaxFileSize: '100mb',
       filesDefaultExpiration: '',
@@ -55,6 +57,12 @@ export default function Files({
       values.filesDefaultExpiration = null;
     } else {
       values.filesDefaultExpiration = values.filesDefaultExpiration.trim();
+    }
+
+    if (values.filesCustomFormat?.trim() === '' || !values.filesCustomFormat) {
+      values.filesCustomFormat = null;
+    } else {
+      values.filesCustomFormat = values.filesCustomFormat.trim();
     }
 
     if (values.filesMaxExpiration?.trim() === '' || !values.filesMaxExpiration) {
@@ -92,6 +100,7 @@ export default function Files({
       filesRoute: data.settings.filesRoute ?? '/u',
       filesLength: data.settings.filesLength ?? 6,
       filesDefaultFormat: data.settings.filesDefaultFormat ?? 'random',
+      filesCustomFormat: data.settings.filesCustomFormat ?? '',
       filesDisabledExtensions: data.settings.filesDisabledExtensions.join(', ') ?? '',
       filesMaxFileSize: data.settings.filesMaxFileSize ?? '100mb',
       filesDefaultExpiration: data.settings.filesDefaultExpiration ?? '',
@@ -143,8 +152,16 @@ export default function Files({
             label='Default Format'
             description='The default format to use for file names.'
             placeholder='random'
-            data={['random', 'date', 'uuid', 'name', 'gfycat']}
+            data={['random', 'date', 'uuid', 'name', 'gfycat', 'custom']}
             {...form.getInputProps('filesDefaultFormat')}
+          />
+
+          <TextInput
+            label='Custom Format'
+            description='Used only when Default Format is set to "custom". This supports the same variables as webhooks and view routes.'
+            placeholder='file-{file.originalName}-{file.size}-{user.username::upper}'
+            {...form.getInputProps('filesCustomFormat')}
+            disabled={form.values.filesDefaultFormat !== 'custom'}
           />
 
           <TextInput

--- a/src/components/pages/upload/UploadOptionsButton.tsx
+++ b/src/components/pages/upload/UploadOptionsButton.tsx
@@ -209,6 +209,7 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
               { value: 'uuid', label: 'UUID' },
               { value: 'name', label: 'Use file name' },
               { value: 'gfycat', label: 'Gfycat-style name' },
+              { value: 'custom', label: 'Custom format' },
             ]}
             label={
               <>
@@ -233,6 +234,23 @@ export default function UploadOptionsButton({ folder, numFiles }: { folder?: str
               },
             }}
           />
+
+          {options.format === 'custom' && (
+            <TextInput
+              label='Custom Name Format'
+              description={
+                <>
+                  Used only when Name Format is set to &quot;custom&quot;. This supports the same variables as
+                  webhooks and view routes.
+                </>
+              }
+              placeholder='file-{file.originalName}-{file.size}-{user.username::upper}'
+              value={options.customFormat || ''}
+              onChange={(event) => {
+                setOption('customFormat', event.target.value || null);
+              }}
+            />
+          )}
 
           <Select
             data={[

--- a/src/lib/api/upload.ts
+++ b/src/lib/api/upload.ts
@@ -5,7 +5,7 @@ import { bytes } from '@/lib/bytes';
 import { config } from '../config';
 import { Config } from '../config/validate';
 import { sanitizeFilename } from '../fs';
-import { formatFileName } from '../uploader/formatFileName';
+import { type CustomFormatOptions, formatFileName } from '../uploader/formatFileName';
 import { guess } from '../mimes';
 import { log } from '../logger';
 
@@ -81,9 +81,12 @@ export async function getFilename(
   originalName: string,
   extension: string,
   override?: string,
+  customFormatOptions?: CustomFormatOptions,
 ): Promise<{ error: string } | { fileName: string }> {
   try {
-    let fileName = override ? sanitizeFilename(override) : formatFileName(format, originalName);
+    let fileName = override
+      ? sanitizeFilename(override)
+      : formatFileName(format, originalName, customFormatOptions);
 
     if (!fileName) return { error: 'invalid file name' };
 
@@ -100,6 +103,21 @@ export async function getFilename(
 
       fullFileName = `${fileName}${extension}`;
       existing = await prisma.file.findFirst({ where: { name: fullFileName } });
+    }
+
+    let customFormatAttempts = 0;
+    while (existing && format === 'custom' && customFormatAttempts++ < 5) {
+      fileName = formatFileName(format, originalName, customFormatOptions);
+      if (!fileName) return { error: 'invalid file name' };
+
+      fullFileName = `${fileName}${extension}`;
+      existing = await prisma.file.findFirst({ where: { name: fullFileName } });
+    }
+    if (existing && format === 'custom') {
+      return {
+        error:
+          'file with the same name already exists, and custom format did not produce a unique name after multiple attempts',
+      };
     }
 
     return { fileName };

--- a/src/lib/client/store/uploadOptions.ts
+++ b/src/lib/client/store/uploadOptions.ts
@@ -5,6 +5,7 @@ import type { Config } from '@/lib/config/validate';
 export const defaultUploadOptions: UploadOptionsStore['options'] = {
   deletesAt: 'default',
   format: 'default',
+  customFormat: null,
   imageCompressionPercent: null,
   imageCompressionFormat: 'default',
   maxViews: null,
@@ -22,6 +23,7 @@ export type UploadOptionsStore = {
   options: {
     deletesAt: string | 'never';
     format: Config['files']['defaultFormat'] | 'default';
+    customFormat: Config['files']['customFormat'] | null;
     imageCompressionPercent: number | null;
     imageCompressionFormat: Config['files']['defaultCompressionFormat'] | 'default';
     maxViews: number | null;

--- a/src/lib/client/upload/shared.tsx
+++ b/src/lib/client/upload/shared.tsx
@@ -70,8 +70,15 @@ export function applyUploadHeaders(
   req: XMLHttpRequest,
   { options, ephemeral, folder }: UploadHeadersOptions,
 ) {
+  const selectedFormat = options.format === 'default' ? null : options.format;
+  const trimmedCustomFormat = typeof options.customFormat === 'string' ? options.customFormat.trim() : null;
+
   options.deletesAt !== 'default' && req.setRequestHeader('x-zipline-deletes-at', options.deletesAt);
-  options.format !== 'default' && req.setRequestHeader('x-zipline-format', options.format);
+  selectedFormat && req.setRequestHeader('x-zipline-format', selectedFormat);
+  selectedFormat === 'custom' &&
+    typeof trimmedCustomFormat === 'string' &&
+    trimmedCustomFormat.length > 0 &&
+    req.setRequestHeader('x-zipline-custom-format', trimmedCustomFormat);
   options.imageCompressionPercent &&
     req.setRequestHeader('x-zipline-image-compression-percent', options.imageCompressionPercent.toString());
   options.imageCompressionFormat !== 'default' &&

--- a/src/lib/config/read/db.ts
+++ b/src/lib/config/read/db.ts
@@ -22,6 +22,7 @@ export const DATABASE_TO_PROP = {
   filesRoute: 'files.route',
   filesLength: 'files.length',
   filesDefaultFormat: 'files.defaultFormat',
+  filesCustomFormat: 'files.customFormat',
   filesDisabledExtensions: 'files.disabledExtensions',
   filesMaxFileSize: 'files.maxFileSize',
   filesDefaultExpiration: 'files.defaultExpiration',

--- a/src/lib/config/read/env.ts
+++ b/src/lib/config/read/env.ts
@@ -56,6 +56,7 @@ export const ENVS = [
   env('files.route', 'FILES_ROUTE', 'string', true),
   env('files.length', 'FILES_LENGTH', 'number', true),
   env('files.defaultFormat', 'FILES_DEFAULT_FORMAT', 'string', true),
+  env('files.customFormat', 'FILES_CUSTOM_FORMAT', 'string', true),
   env('files.disabledExtensions', 'FILES_DISABLED_EXTENSIONS', 'string[]', true),
   env('files.maxFileSize', 'FILES_MAX_FILE_SIZE', 'string', true),
   env('files.defaultExpiration', 'FILES_DEFAULT_EXPIRATION', 'string', true),

--- a/src/lib/config/read/index.ts
+++ b/src/lib/config/read/index.ts
@@ -39,6 +39,7 @@ export const rawConfig: any = {
     route: undefined,
     length: undefined,
     defaultFormat: undefined,
+    customFormat: undefined,
     disabledExtensions: undefined,
     maxFileSize: undefined,
     defaultExpiration: undefined,

--- a/src/lib/config/validate.ts
+++ b/src/lib/config/validate.ts
@@ -127,25 +127,40 @@ export const schema = z.object({
     metricsInterval: intervalSchema('30min'),
     cleanThumbnailsInterval: intervalSchema('1d'),
   }),
-  files: z.object({
-    route: z.string().startsWith('/').min(1).trim().toLowerCase().default('/u'),
-    length: z.number().default(6),
-    defaultFormat: z.enum(['random', 'date', 'uuid', 'name', 'gfycat', 'random-words']).default('random'),
-    disabledExtensions: z.array(z.string()).default([]),
-    maxFileSize: z.string().default('100mb'),
-    defaultExpiration: z.string().nullable().default(null),
-    maxExpiration: z.string().nullable().default(null),
-    assumeMimetypes: z.boolean().default(false),
-    defaultDateFormat: z.string().default('YYYY-MM-DD_HH:mm:ss'),
-    removeGpsMetadata: z.boolean().default(false),
-    randomWordsNumAdjectives: z.number().default(3),
-    randomWordsSeparator: z.string().default('-'),
-    defaultCompressionFormat: z
-      .enum(COMPRESS_TYPES)
-      .default('jpg')
-      .refine((v) => checkOutput(v), 'System does not support outputting this image format.'),
-    maxFilesPerUpload: z.number().max(2147483647).min(1).default(1000),
-  }),
+  files: z
+    .object({
+      route: z.string().startsWith('/').min(1).trim().toLowerCase().default('/u'),
+      length: z.number().default(6),
+      defaultFormat: z
+        .enum(['random', 'date', 'uuid', 'name', 'gfycat', 'random-words', 'custom'])
+        .default('random'),
+      customFormat: z.string().nullable().default(null),
+      disabledExtensions: z.array(z.string()).default([]),
+      maxFileSize: z.string().default('100mb'),
+      defaultExpiration: z.string().nullable().default(null),
+      maxExpiration: z.string().nullable().default(null),
+      assumeMimetypes: z.boolean().default(false),
+      defaultDateFormat: z.string().default('YYYY-MM-DD_HH:mm:ss'),
+      removeGpsMetadata: z.boolean().default(false),
+      randomWordsNumAdjectives: z.number().default(3),
+      randomWordsSeparator: z.string().default('-'),
+      defaultCompressionFormat: z
+        .enum(COMPRESS_TYPES)
+        .default('jpg')
+        .refine((v) => checkOutput(v), 'System does not support outputting this image format.'),
+      maxFilesPerUpload: z.number().max(2147483647).min(1).default(1000),
+    })
+    .superRefine((data, ctx) => {
+      if (data.defaultFormat !== 'custom') return;
+
+      if (!data.customFormat?.trim()) {
+        ctx.addIssue({
+          path: ['customFormat'],
+          message: 'customFormat must be set when defaultFormat is custom',
+          code: 'custom',
+        });
+      }
+    }),
   urls: z.object({
     route: z.string().startsWith('/').min(1).trim().toLowerCase().default('/go'),
     length: z.number().default(6),

--- a/src/lib/uploader/formatFileName.ts
+++ b/src/lib/uploader/formatFileName.ts
@@ -1,12 +1,28 @@
 import dayjs from 'dayjs';
 import { config } from '../config';
 import { Config } from '../config/validate';
+import type { File } from '../db/models/file';
+import type { User } from '../db/models/user';
+import { parseString } from '../parser';
+import type { parserMetrics } from '../parser/metrics';
 import { randomCharacters } from '../random';
 import { randomUUID } from 'crypto';
 import { parse } from 'path';
 import { randomWords } from './randomWords';
+import { sanitizeFilename } from '../fs';
 
-export function formatFileName(nameFormat: Config['files']['defaultFormat'], originalName?: string) {
+export type CustomFormatOptions = {
+  customFormat: string | null;
+  file: File;
+  user: User;
+  metrics: Awaited<ReturnType<typeof parserMetrics>> | null;
+};
+
+export function formatFileName(
+  nameFormat: Config['files']['defaultFormat'],
+  originalName?: string,
+  customFormatOptions?: CustomFormatOptions,
+) {
   switch (nameFormat) {
     case 'random':
       return randomCharacters(config.files.length);
@@ -23,6 +39,16 @@ export function formatFileName(nameFormat: Config['files']['defaultFormat'], ori
     case 'random-words':
     case 'gfycat':
       return randomWords(config.files.randomWordsNumAdjectives, config.files.randomWordsSeparator);
+    case 'custom':
+      if (!customFormatOptions) throw new Error('customFormatOptions is required for custom format');
+      if (!customFormatOptions.customFormat) return null;
+      const parsedFormat = parseString(customFormatOptions.customFormat, {
+        file: customFormatOptions.file,
+        user: customFormatOptions.user,
+        ...(customFormatOptions.metrics ?? {}),
+      });
+      if (!parsedFormat) return null;
+      return sanitizeFilename(parsedFormat);
     default:
       return randomCharacters(config.files.length);
   }

--- a/src/lib/uploader/parseHeaders.ts
+++ b/src/lib/uploader/parseHeaders.ts
@@ -46,6 +46,7 @@ type StringBoolean = 'true' | 'false';
 export type UploadHeaders = {
   'x-zipline-deletes-at'?: string;
   'x-zipline-format'?: Config['files']['defaultFormat'];
+  'x-zipline-custom-format'?: string;
 
   'x-zipline-image-compression-type'?: CompressType;
   'x-zipline-image-compression-percent'?: string;
@@ -73,6 +74,7 @@ export type UploadHeaders = {
 export type UploadOptions = {
   deletesAt?: Date | 'never';
   format?: Config['files']['defaultFormat'];
+  customFormat?: string | null;
   password?: string;
   maxViews?: number;
   noJson?: boolean;
@@ -150,7 +152,7 @@ function parsePercent(header: keyof UploadHeaders, percent: string) {
   return num;
 }
 
-const FORMATS = ['random', 'uuid', 'date', 'name', 'gfycat', 'random-words'];
+const FORMATS = ['random', 'uuid', 'date', 'name', 'gfycat', 'random-words', 'custom'];
 
 export function parseHeaders(headers: UploadHeaders, fileConfig: Config['files']): UploadOptions {
   const response: UploadOptions = {};
@@ -190,6 +192,25 @@ export function parseHeaders(headers: UploadHeaders, fileConfig: Config['files']
     response.format = format;
   } else {
     response.format = fileConfig.defaultFormat;
+  }
+
+  const customFormat = headers['x-zipline-custom-format'];
+  if (customFormat) {
+    if (response.format === 'custom') {
+      response.customFormat = customFormat;
+    }
+  } else {
+    response.customFormat = fileConfig.customFormat;
+  }
+  if (response.format === 'custom') {
+    const effectiveCustomFormat = response.customFormat?.trim();
+    if (!effectiveCustomFormat)
+      return throwHeaderError(
+        'x-zipline-custom-format',
+        'Custom format is required when x-zipline-format is set to custom',
+      );
+
+    response.customFormat = effectiveCustomFormat;
   }
 
   const imageCompressionPercent = headers['x-zipline-image-compression-percent'];

--- a/src/server/routes/api/server/public.ts
+++ b/src/server/routes/api/server/public.ts
@@ -41,6 +41,7 @@ const publicConfigSchema = z.object({
   files: z.object({
     maxFileSize: z.string(),
     defaultFormat: configSchema.shape.files.shape.defaultFormat,
+    customFormat: z.string().nullable().optional(),
     maxExpiration: z.string().nullable().optional(),
   }),
   chunks: configSchema.shape.chunks,
@@ -92,6 +93,7 @@ export default typedPlugin(
           files: {
             maxFileSize: config.files.maxFileSize,
             defaultFormat: config.files.defaultFormat,
+            customFormat: config.files.customFormat,
             maxExpiration: config.files.maxExpiration,
           },
           chunks: config.chunks,

--- a/src/server/routes/api/server/settings/index.ts
+++ b/src/server/routes/api/server/settings/index.ts
@@ -181,7 +181,8 @@ export default typedPlugin(
                 'Provided route is reserved',
               ),
             filesLength: z.number().min(1).max(64),
-            filesDefaultFormat: z.enum(['random', 'date', 'uuid', 'name', 'gfycat']),
+            filesDefaultFormat: z.enum(['random', 'date', 'uuid', 'name', 'gfycat', 'custom']),
+            filesCustomFormat: z.string().nullable(),
             filesDisabledExtensions: z
               .union([
                 z.array(z.string().refine((s) => !s.startsWith('.'), 'extension can\'t include "."')),
@@ -440,6 +441,19 @@ export default typedPlugin(
           .refine((data) => !data.ratelimitWindow || (data.ratelimitMax && data.ratelimitMax > 0), {
             message: 'ratelimitMax must be set if ratelimitWindow is set',
             path: ['ratelimitMax'],
+          })
+          .superRefine((data, ctx) => {
+            const effectiveDefaultFormat = data.filesDefaultFormat ?? settings.filesDefaultFormat;
+            if (effectiveDefaultFormat !== 'custom') return;
+
+            const effectiveCustomFormat = data.filesCustomFormat ?? settings.filesCustomFormat;
+            if (!effectiveCustomFormat?.trim()) {
+              ctx.addIssue({
+                path: ['filesCustomFormat'],
+                message: 'filesCustomFormat must be set when filesDefaultFormat is custom',
+                code: 'custom',
+              });
+            }
           })
           .superRefine((data, ctx) => {
             if (!data.filesDefaultExpiration || !data.filesMaxExpiration) return;

--- a/src/server/routes/api/upload/index.ts
+++ b/src/server/routes/api/upload/index.ts
@@ -10,6 +10,8 @@ import { fileSelect } from '@/lib/db/models/file';
 import { sanitizeFilename } from '@/lib/fs';
 import { removeGps } from '@/lib/gps';
 import { log } from '@/lib/logger';
+import { parserMetrics } from '@/lib/parser/metrics';
+import type { CustomFormatOptions } from '@/lib/uploader/formatFileName';
 import { runThumbnailWorkers } from '@/lib/tasks/run/thumbnails';
 import { parseHeaders, UploadHeaders } from '@/lib/uploader/parseHeaders';
 import { onUpload } from '@/lib/webhooks';
@@ -131,6 +133,9 @@ export default typedPlugin(
           req.headers.host,
         );
 
+        const metrics =
+          options.format === 'custom' && req.user?.id != null ? await parserMetrics(req.user.id) : null;
+
         logger.debug('uploading files', { files: files.map((x) => x.filename) });
 
         for (let i = 0; i !== files.length; ++i) {
@@ -147,7 +152,43 @@ export default typedPlugin(
 
           // determine filename
           const format = options.format || config.files.defaultFormat;
-          const nameResult = await getFilename(format, file.filename, extension, options.overrides?.filename);
+          const customFormatOptions =
+            format === 'custom'
+              ? ({
+                  customFormat: options.customFormat || config.files.customFormat,
+                  user: req.user ?? {
+                    id: 'anonymous',
+                    username: 'anonymous',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    role: 'USER',
+                  },
+                  file: {
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    originalName: file.filename,
+                    name: file.filename,
+                    size: file.file.bytesRead,
+                    type: file.mimetype,
+                    deletesAt: options.deletesAt && options.deletesAt !== 'never' ? options.deletesAt : null,
+                    favorite: false,
+                    folderId: options.folder ?? null,
+                    views: 0,
+                    anonymous: !req.user && options.folder ? true : false,
+                    id: 'no-id-yet',
+                    thumbnail: null,
+                    maxViews: options.maxViews ?? null,
+                  },
+                  metrics,
+                } satisfies CustomFormatOptions)
+              : undefined;
+          const nameResult = await getFilename(
+            format,
+            file.filename,
+            extension,
+            options.overrides?.filename,
+            customFormatOptions,
+          );
           if ('error' in nameResult) throw new ApiError(1009, `file[${i}]: ${nameResult.error}`);
 
           const { fileName } = nameResult;

--- a/src/server/routes/api/upload/partial.ts
+++ b/src/server/routes/api/upload/partial.ts
@@ -6,6 +6,8 @@ import { hashPassword } from '@/lib/crypto';
 import { prisma } from '@/lib/db';
 import { sanitizeFilename } from '@/lib/fs';
 import { log } from '@/lib/logger';
+import { parserMetrics } from '@/lib/parser/metrics';
+import type { CustomFormatOptions } from '@/lib/uploader/formatFileName';
 import { guess } from '@/lib/mimes';
 import { randomCharacters } from '@/lib/random';
 import { UploadHeaders, UploadOptions, parseHeaders } from '@/lib/uploader/parseHeaders';
@@ -155,11 +157,42 @@ export default typedPlugin(
 
           // determine filename
           const format = options.format || config.files.defaultFormat;
+          const customFormatOptions =
+            format === 'custom'
+              ? ({
+                  customFormat: options.customFormat || config.files.customFormat,
+                  metrics: req.user?.id != null ? await parserMetrics(req.user.id) : null,
+                  user: req.user ?? {
+                    id: 'anonymous',
+                    username: 'anonymous',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    role: 'USER',
+                  },
+                  file: {
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    originalName: options.partial.filename,
+                    name: options.partial.filename,
+                    size: options.partial.range[2],
+                    type: file.mimetype,
+                    deletesAt: options.deletesAt && options.deletesAt !== 'never' ? options.deletesAt : null,
+                    favorite: false,
+                    folderId: options.folder ?? null,
+                    views: 0,
+                    anonymous: !req.user && options.folder ? true : false,
+                    id: 'no-id-yet',
+                    thumbnail: null,
+                    maxViews: options.maxViews ?? null,
+                  },
+                } satisfies CustomFormatOptions)
+              : undefined;
           const nameResult = await getFilename(
             format,
             options.partial.filename,
             extension,
             options.overrides?.filename,
+            customFormatOptions,
           );
           if ('error' in nameResult) throw new ApiError(1009, nameResult.error);
 


### PR DESCRIPTION
## Custom Filename Formats

This PR adds a new filename format allowing users & administrators to easily build one according to their needs (see #1025).

### Usage
1. Administrators can configure a default either in settings or using the environment variable; just like with the other formats
2. On every upload, users can manually select the `custom` format and enter their wanted format
3. Integrations can use the following combination of headers during upload requests to override the format:
```
x-zipline-format: custom
x-zipline-custom-format: {file.originalName}-{file.createdAt::time}
```

#### Format Syntax
This implementation reuses the existing variables system for it's syntax (see variables for webhooks & view routes). Currently, a few things that I feel like would be quite important for this feature are missing, like the following:
- `{random::length}` -> generates a random string with a specified length, returns a string so further modifiers are possible (e.g. `{random::3::upper}`)
- `{gfycat:adjectiveCount}` -> generates a gfycat name (0 = just an animal, 1... = animal with 1... adjectives)
- `{file.createdAt::default}` -> uses the default date format configured in settings
- `{file.createdAt::YYYY-MM-DD}` -> uses a custom date format

Especially these date formats are important since the currently provided ones all resolve to a date with slashes (afaik?), i.e. illegal filenames. Please feel free to suggest any different ideas you may have on this.

### Added Configuration Keys
- Added `filesCustomFormat` field to database schema
- Added `custom` filename format
- Added `x-zipline-custom-format` header to uploads