### PR TITLE
fix: return 404 status on not-found SPA fallback (#1061)

### DIFF
--- a/src/server/startup/handlers.ts
+++ b/src/server/startup/handlers.ts
@@ -19,6 +19,7 @@ export function registerHandlers(server: FastifyInstance, mode: string) {
         statusCode: 404,
       });
     } else {
+      res.status(404);
       return res.serveIndex();
     }
   });


### PR DESCRIPTION
The non-API branch of setNotFoundHandler served the Next.js index shell without setting the status code, so clients saw HTTP 200 with a Not-Found UI. This broke monitoring, ingress proxy_intercept_errors rules, crawlers, and curl -f. Set status 404 explicitly before serving the index.

Closes #1061