### PR TITLE
avoid extra copies for local uploads

### DIFF
--- a/src/lib/datasource/Local.ts
+++ b/src/lib/datasource/Local.ts
@@ -13,6 +13,10 @@ async function existsAndCanRW(path: string): Promise<boolean> {
   }
 }
 
+function isCrossDeviceMove(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'EXDEV';
+}
+
 export class LocalDatasource extends Datasource {
   name = 'local';
 
@@ -44,13 +48,22 @@ export class LocalDatasource extends Datasource {
       throw new Error('Invalid path provided');
     }
 
-    // handles if given a path to a file, it will just move it instead of doing unecessary writes
+    // handles path-based writes without duplicating bytes when the source can be consumed
     if (typeof data === 'string' && data.startsWith('/')) {
       const exists = await existsAndCanRW(data);
       if (!exists)
         throw new Error(
           "Something went very wrong! the temporary directory wasn't readable or the file doesn't exist.",
         );
+
+      if (!noDelete) {
+        try {
+          await rename(data, path);
+          return;
+        } catch (e) {
+          if (!isCrossDeviceMove(e)) throw e;
+        }
+      }
 
       await copyFile(data, path);
 


### PR DESCRIPTION
this changes local uploads to move the temp file into place instead of copying it and then deleting the temp file.

if the temp dir and uploads dir are on different filesystems, it falls back to the old copy/delete behavior. `noDelete` still copies like before, so import flows don't accidentally lose their source files.

## why?

normal uploads already get written to a temp file first. for local storage we were then doing another full file copy into the uploads dir, which is pretty wasteful for big files. when it's the same filesystem, `rename` is basically instant.