### PR TITLE
fix folders page loading with large file counts

### DIFF
--- a/prisma/migrations/20260508022000_add_file_folder_created_at_index/migration.sql
+++ b/prisma/migrations/20260508022000_add_file_folder_created_at_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "File_folderId_createdAt_idx" ON "public"."File"("folderId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -295,6 +295,8 @@ model File {
   folderId String?
 
   thumbnail Thumbnail?
+
+  @@index([folderId, createdAt])
 }
 
 model Thumbnail {

--- a/src/components/pages/folders/index.tsx
+++ b/src/components/pages/folders/index.tsx
@@ -55,7 +55,7 @@ export default function DashboardFolders() {
     data: currentFolder,
     error: currentFolderError,
     isLoading,
-  } = useSWR<Folder>(currentFolderId ? `/api/user/folders/${currentFolderId}` : null);
+  } = useSWR<Folder>(currentFolderId ? `/api/user/folders/${currentFolderId}?noincl=true` : null);
 
   const form = useForm({
     initialValues: {

--- a/src/components/pages/folders/views/FolderGridView.tsx
+++ b/src/components/pages/folders/views/FolderGridView.tsx
@@ -12,7 +12,7 @@ export default function FolderGridView({
   currentFolderId: string | null;
   onNavigate: (folderId: string | null) => void;
 }) {
-  const queryParam = currentFolderId ? `?parentId=${currentFolderId}` : '?root=true';
+  const queryParam = currentFolderId ? `?parentId=${currentFolderId}&noincl=true` : '?root=true&noincl=true';
   const { data: folders, isLoading } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
     `/api/user/folders${queryParam}`,
   );

--- a/src/components/pages/folders/views/FolderTableView.tsx
+++ b/src/components/pages/folders/views/FolderTableView.tsx
@@ -119,7 +119,7 @@ export default function FolderTableView({
 }) {
   const clipboard = useClipboard();
 
-  const queryParam = currentFolderId ? `?parentId=${currentFolderId}` : '?root=true';
+  const queryParam = currentFolderId ? `?parentId=${currentFolderId}&noincl=true` : '?root=true&noincl=true';
   const { data, isLoading } = useSWR<Extract<Response['/api/user/folders'], Folder[]>>(
     `/api/user/folders${queryParam}`,
   );

--- a/src/lib/datasource/Local.ts
+++ b/src/lib/datasource/Local.ts
@@ -13,6 +13,10 @@ async function existsAndCanRW(path: string): Promise<boolean> {
   }
 }
 
+function isCrossDeviceMove(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'EXDEV';
+}
+
 export class LocalDatasource extends Datasource {
   name = 'local';
 
@@ -44,13 +48,22 @@ export class LocalDatasource extends Datasource {
       throw new Error('Invalid path provided');
     }
 
-    // handles if given a path to a file, it will just move it instead of doing unecessary writes
+    // handles path-based writes without duplicating bytes when the source can be consumed
     if (typeof data === 'string' && data.startsWith('/')) {
       const exists = await existsAndCanRW(data);
       if (!exists)
         throw new Error(
           "Something went very wrong! the temporary directory wasn't readable or the file doesn't exist.",
         );
+
+      if (!noDelete) {
+        try {
+          await rename(data, path);
+          return;
+        } catch (e) {
+          if (!isCrossDeviceMove(e)) throw e;
+        }
+      }
 
       await copyFile(data, path);
 

--- a/src/server/routes/api/user/folders/[id]/index.ts
+++ b/src/server/routes/api/user/folders/[id]/index.ts
@@ -5,7 +5,7 @@ import { buildParentChain, Folder, cleanFolder, folderSchema } from '@/lib/db/mo
 import { User } from '@/lib/db/models/user';
 import { log } from '@/lib/logger';
 import { canInteract } from '@/lib/role';
-import { zStringTrimmed } from '@/lib/validation';
+import { zQsBoolean, zStringTrimmed } from '@/lib/validation';
 import { userMiddleware } from '@/server/middleware/user';
 import typedPlugin from '@/server/typedPlugin';
 import { FastifyRequest } from 'fastify';
@@ -52,8 +52,11 @@ export default typedPlugin(
       PATH,
       {
         schema: {
-          description: 'Fetch a specific folder by ID, including files, children, and its parent chain.',
+          description: 'Fetch a specific folder by ID, optionally including files, children, and its parent chain.',
           params: paramsSchema,
+          querystring: z.object({
+            noincl: zQsBoolean.optional(),
+          }),
           response: {
             200: folderSchema.partial(),
           },
@@ -63,18 +66,21 @@ export default typedPlugin(
       },
       async (req, res) => {
         const { id } = req.params;
+        const { noincl } = req.query;
 
         const folder = await prisma.folder.findUnique({
           where: {
             id,
           },
           include: {
-            files: {
-              select: {
-                ...fileSelect,
-                password: true,
+            ...(!noincl && {
+              files: {
+                select: {
+                  ...fileSelect,
+                  password: true,
+                },
               },
-            },
+            }),
             User: true,
             children: {
               orderBy: { createdAt: 'desc' },

--- a/src/server/routes/api/user/folders/[id]/index.ts
+++ b/src/server/routes/api/user/folders/[id]/index.ts
@@ -52,7 +52,8 @@ export default typedPlugin(
       PATH,
       {
         schema: {
-          description: 'Fetch a specific folder by ID, optionally including files, children, and its parent chain.',
+          description:
+            'Fetch a specific folder by ID, optionally including files, children, and its parent chain.',
           params: paramsSchema,
           querystring: z.object({
             noincl: zQsBoolean.optional(),


### PR DESCRIPTION
this stops the folders page from trying to load every file in every folder.

folder list + current folder requests now use noincl so they only pull folder metadata/counts. the single folder endpoint also supports noincl now.

also added an index on file folderId + createdAt since folder file views count/page through files by folder.